### PR TITLE
Moving SQLite Trigger drop to inital connection instead of on every q…

### DIFF
--- a/SpatialConnect/GeopackageFileAdapter.m
+++ b/SpatialConnect/GeopackageFileAdapter.m
@@ -322,7 +322,9 @@
         __block int perLayer;
         [queryLayers enumerateObjectsUsingBlock:^(NSString *tableName,
                                                   NSUInteger idx, BOOL *stop) {
-          perLayer = filterLimit / queryLayers.count;
+          perLayer = filterLimit <= queryLayers.count
+                         ? filterLimit
+                         : filterLimit / queryLayers.count;
           GPKGFeatureDao *dao =
               [self.gpkg getFeatureDaoWithTableName:tableName];
           rs = [dao queryForAll];

--- a/SpatialConnect/SCDataService.m
+++ b/SpatialConnect/SCDataService.m
@@ -305,9 +305,6 @@ NSString *const kSERVICENAME = @"DATASERVICE";
         }
             error:^(NSError *error) {
               [subscriber sendError:error];
-            }
-            completed:^{
-              [subscriber sendCompleted];
             }];
         return nil;
       }];

--- a/SpatialConnectTests/SCGeopackageDeleteTest.m
+++ b/SpatialConnectTests/SCGeopackageDeleteTest.m
@@ -45,17 +45,21 @@
   SCQueryFilter *filter = [[SCQueryFilter alloc] init];
   filter.limit = 1;
   [[SCGeopackageHelper loadGPKGDataStore:self.sc]
-      subscribeNext:^(GeopackageStore *ds) {
+      subscribeNext:^(id<SCSpatialStore> ds) {
         [[[ds query:filter] flattenMap:^RACStream *(SCSpatialFeature *f) {
           return [ds delete:f.key];
         }] subscribeError:^(NSError *error) {
-          XCTFail(@"Error loading GPGK");
+          XCTFail(@"Error Deleting Feature");
           [expect fulfill];
         }
             completed:^{
-              XCTAssert(YES, @"Delete successfully");
               [expect fulfill];
             }];
+
+      }
+      error:^(NSError *error) {
+        XCTFail(@"Error getting store");
+        [expect fulfill];
       }];
 
   [self.sc startAllServices];


### PR DESCRIPTION
…uery. Trying to drop the triggers on each query can create a race condition where the database is locked for reading.
