### PR TITLE
Adding reactive config to iOS lib

### DIFF
--- a/SpatialConnect.xcodeproj/project.pbxproj
+++ b/SpatialConnect.xcodeproj/project.pbxproj
@@ -229,6 +229,8 @@
 		5677D6DB1C3F046E00C1E0F2 /* SCRasterStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 5677D6DA1C3F046E00C1E0F2 /* SCRasterStore.h */; };
 		56789C401C32C0AC001B5ABE /* SCSimplePoint.h in Headers */ = {isa = PBXBuildFile; fileRef = 56789C3E1C32C0AC001B5ABE /* SCSimplePoint.h */; };
 		56789C411C32C0AC001B5ABE /* SCSimplePoint.m in Sources */ = {isa = PBXBuildFile; fileRef = 56789C3F1C32C0AC001B5ABE /* SCSimplePoint.m */; };
+		56B2A6551C97408500464076 /* SCConfigService.h in Headers */ = {isa = PBXBuildFile; fileRef = 56B2A6531C97408500464076 /* SCConfigService.h */; };
+		56B2A6561C97408500464076 /* SCConfigService.m in Sources */ = {isa = PBXBuildFile; fileRef = 56B2A6541C97408500464076 /* SCConfigService.m */; };
 		56DC516A1BFC2315002C71B3 /* SpatialConnect.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5649B4931BE27C6A009947EF /* SpatialConnect.framework */; };
 		56DC516D1BFD22AB002C71B3 /* SCServiceStatusEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = 56DC516B1BFD22AB002C71B3 /* SCServiceStatusEvent.h */; };
 		56DC516E1BFD22AB002C71B3 /* SCServiceStatusEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = 56DC516C1BFD22AB002C71B3 /* SCServiceStatusEvent.m */; };
@@ -480,6 +482,8 @@
 		5677D6DA1C3F046E00C1E0F2 /* SCRasterStore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SCRasterStore.h; sourceTree = "<group>"; };
 		56789C3E1C32C0AC001B5ABE /* SCSimplePoint.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SCSimplePoint.h; sourceTree = "<group>"; };
 		56789C3F1C32C0AC001B5ABE /* SCSimplePoint.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SCSimplePoint.m; sourceTree = "<group>"; };
+		56B2A6531C97408500464076 /* SCConfigService.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SCConfigService.h; sourceTree = "<group>"; };
+		56B2A6541C97408500464076 /* SCConfigService.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SCConfigService.m; sourceTree = "<group>"; };
 		56DC51381BFBEF71002C71B3 /* libgeopackage-ios.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libgeopackage-ios.a"; path = "Pods/../build/Debug-iphoneos/libgeopackage-ios.a"; sourceTree = "<group>"; };
 		56DC513D1BFC0CD0002C71B3 /* libPods.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libPods.a; path = "Pods/../build/Debug-iphoneos/libPods.a"; sourceTree = "<group>"; };
 		56DC51681BFC230B002C71B3 /* libPods.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libPods.a; path = "Pods/../build/Debug-iphoneos/libPods.a"; sourceTree = "<group>"; };
@@ -920,6 +924,7 @@
 		5649B4951BE27C6A009947EF /* SpatialConnect */ = {
 			isa = PBXGroup;
 			children = (
+				56B2A6521C97385800464076 /* ConfigService */,
 				567B1FD31BFD5CB6003254C7 /* Events */,
 				563BEC6B1BE52A6B00778EDA /* NetworkService */,
 				563BEC691BE52A2400778EDA /* RasterService */,
@@ -1047,6 +1052,15 @@
 			name = Data;
 			sourceTree = "<group>";
 		};
+		56B2A6521C97385800464076 /* ConfigService */ = {
+			isa = PBXGroup;
+			children = (
+				56B2A6531C97408500464076 /* SCConfigService.h */,
+				56B2A6541C97408500464076 /* SCConfigService.m */,
+			);
+			name = ConfigService;
+			sourceTree = "<group>";
+		};
 		B50F784BAECD0A5117CB7E1B /* Pods */ = {
 			isa = PBXGroup;
 			children = (
@@ -1159,6 +1173,7 @@
 				5649B6221BE283EC009947EF /* SpatialConnect.h in Headers */,
 				5649B5F91BE280D6009947EF /* SCPolygon+GeoJSON.h in Headers */,
 				5649B6181BE280D6009947EF /* SCTileOverlay.h in Headers */,
+				56B2A6551C97408500464076 /* SCConfigService.h in Headers */,
 				5649B5AD1BE280D6009947EF /* SCFilterNotLike.h in Headers */,
 				5649B5DF1BE280D6009947EF /* SCMultiLineString+MapKit.h in Headers */,
 				5649B61C1BE280D6009947EF /* SCUserPrefs.h in Headers */,
@@ -1388,6 +1403,7 @@
 				5649B5B31BE280D6009947EF /* SCGeoFilterContains.m in Sources */,
 				5649B5AC1BE280D6009947EF /* SCFilterNotIn.m in Sources */,
 				5649B6081BE280D6009947EF /* SCSensorService.m in Sources */,
+				56B2A6561C97408500464076 /* SCConfigService.m in Sources */,
 				5649B5851BE280D6009947EF /* SCBoundingBox.m in Sources */,
 				5649B5811BE280D6009947EF /* GeoJSONStore.m in Sources */,
 				560A71291BE8577000CE473F /* GeopackageFileAdapter.m in Sources */,

--- a/SpatialConnect/SCConfigService.h
+++ b/SpatialConnect/SCConfigService.h
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2016 Boundless http://boundlessgeo.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+#import "SCService.h"
+
+typedef NS_ENUM(NSInteger, SCConfigEvent) {
+  SC_CONFIG_SERVICE_ADDED,
+  SC_CONFIG_SERVICE_REMOVED,
+  SC_CONFIG_DATASERVICE_STORE_ADDED,
+  SC_CONFIG_DATASERVICE_STORE_REMOVED
+};
+
+@interface SCConfigService : SCService {
+  NSMutableArray *configPaths;
+}
+
+- (id)initWithFilepath:(NSString *)filepath;
+- (id)initWithFilepaths:(NSArray *)filepaths;
+- (RACSignal *)load;
+
+@end

--- a/SpatialConnect/SCConfigService.m
+++ b/SpatialConnect/SCConfigService.m
@@ -1,0 +1,108 @@
+/**
+ * Copyright 2016 Boundless http://boundlessgeo.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+#import "SCConfigService.h"
+#import "SCFileUtils.h"
+#import "SCStoreConfig.h"
+
+@implementation SCConfigService
+
+- (id)init {
+  self = [super init];
+  if (self) {
+    configPaths = [NSMutableArray new];
+    [self sweepDataDirectory];
+  }
+  return self;
+}
+
+- (id)initWithFilepath:(NSString *)filepath {
+  self = [super init];
+  if (self) {
+    configPaths = [NSMutableArray new];
+    [configPaths addObject:filepath];
+  }
+
+  return self;
+}
+
+- (id)initWithFilepaths:(NSArray *)filepaths {
+  self = [super init];
+  if (self) {
+    configPaths = [NSMutableArray new];
+    [configPaths addObjectsFromArray:filepaths];
+  }
+  return self;
+}
+
+- (RACSignal *)load {
+  return
+      [RACSignal createSignal:^RACDisposable *(id<RACSubscriber> subscriber) {
+        [configPaths enumerateObjectsUsingBlock:^(NSString *fp, NSUInteger idx,
+                                                  BOOL *_Nonnull stop) {
+          NSError *error;
+          NSDictionary *cfg = [SCFileUtils jsonFileToDict:fp error:&error];
+          if (error) {
+            [subscriber sendError:error];
+          }
+
+          [cfg[@"stores"] enumerateObjectsUsingBlock:^(NSDictionary *d,
+                                                       NSUInteger i, BOOL *s) {
+            SCStoreConfig *cfg = [[SCStoreConfig alloc] initWithDictionary:d];
+            RACTuple *tuple =
+                [RACTuple tupleWithObjects:@(SC_CONFIG_DATASERVICE_STORE_ADDED),
+                                           cfg, nil];
+            [subscriber sendNext:tuple];
+          }];
+
+          [subscriber sendCompleted];
+        }];
+        return nil;
+      }];
+}
+
+- (void)start {
+  [super start];
+}
+
+- (void)stop {
+  [super stop];
+}
+
+#pragma mark -
+#pragma mark Private
+
+- (void)sweepDataDirectory {
+  NSString *path = [NSSearchPathForDirectoriesInDomains(
+      NSDocumentDirectory, NSUserDomainMask, YES) objectAtIndex:0];
+  NSArray *dirs =
+      [[NSFileManager defaultManager] contentsOfDirectoryAtPath:path
+                                                          error:NULL];
+
+  [[[dirs.rac_sequence filter:^BOOL(NSString *filename) {
+    if ([filename.pathExtension.lowercaseString isEqualToString:@"scfg"]) {
+      return YES;
+    } else {
+      return NO;
+    }
+  }] signal] subscribeNext:^(NSString *cfgFileName) {
+    [configPaths
+        addObject:[NSString stringWithFormat:@"%@/%@", path, cfgFileName]];
+
+  }];
+}
+
+@end

--- a/SpatialConnect/SCDataService.m
+++ b/SpatialConnect/SCDataService.m
@@ -152,13 +152,11 @@ NSString *const kSERVICENAME = @"DATASERVICE";
 - (void)start {
   [super start];
   [self startAllStores];
-  self.storesStarted = YES;
 }
 
 - (void)stop {
   [super stop];
   [self stopAllStores];
-  self.storesStarted = NO;
 }
 
 /**

--- a/SpatialConnect/SCNetworkService.h
+++ b/SpatialConnect/SCNetworkService.h
@@ -17,13 +17,18 @@
 * under the License.
 ******************************************************************************/
 
-
-
-
-
-#import <Foundation/Foundation.h>
 #import "SCService.h"
+#import <Foundation/Foundation.h>
 
 @interface SCNetworkService : SCService
+
+/*!
+ *  @brief returns NSDictionary on signal
+ *
+ *  @param url http/https resource with JSON Response
+ *
+ *  @return NSDictionary over RACSignal
+ */
+- (RACSignal *)requestURLAsDict:(NSURL *)url;
 
 @end

--- a/SpatialConnect/SCNetworkService.m
+++ b/SpatialConnect/SCNetworkService.m
@@ -17,11 +17,24 @@
 * under the License.
 ******************************************************************************/
 
-
-
-
+#import "JSONKit.h"
 #import "SCNetworkService.h"
 
 @implementation SCNetworkService
+
+- (RACSignal *)requestURLAsDict:(NSURL *)url {
+  NSURLRequest *request = [[NSURLRequest alloc] initWithURL:url];
+  return [[[NSURLConnection rac_sendAsynchronousRequest:request]
+      reduceEach:^id(NSURLResponse *response, NSData *data) {
+        return data;
+      }] flattenMap:^RACSignal *(NSData *d) {
+    NSError *err;
+    NSDictionary *dict = [[JSONDecoder decoder] objectWithData:d error:&err];
+    if (err) {
+      return [RACSignal error:err];
+    }
+    return [RACSignal return:dict];
+  }];
+}
 
 @end

--- a/SpatialConnect/SCSensorService.h
+++ b/SpatialConnect/SCSensorService.h
@@ -17,39 +17,33 @@
 * under the License.
 ******************************************************************************/
 
-
-
-
-
-#import <Foundation/Foundation.h>
-#import <ReactiveCocoa/ReactiveCocoa.h>
-#import <ReactiveCocoa/RACSignal.h>
-//#import <RXCollections/RXCollection.h>
-
 #import "SCService.h"
+#import <Foundation/Foundation.h>
+#import <ReactiveCocoa/RACSignal.h>
+#import <ReactiveCocoa/ReactiveCocoa.h>
 
 @import CoreLocation;
 
 typedef enum : NSUInteger {
-    SC_LOCATION_HIGH = 0,
-    SC_LOCATION_NAVIGATION = 1,
-    SC_LOCATION_LOW = 3
+  SC_LOCATION_HIGH = 0,
+  SC_LOCATION_NAVIGATION = 1,
+  SC_LOCATION_LOW = 3
 } SCLocationAccuracy;
 
-@interface SCSensorService : SCService <CLLocationManagerDelegate>
-{
-    __strong CLLocationManager *locationManager;
-    CLLocationDistance distance;
-    CLLocationAccuracy accuracy;
+@interface SCSensorService : SCService <CLLocationManagerDelegate> {
+  __strong CLLocationManager *locationManager;
+  CLLocationDistance distance;
+  CLLocationAccuracy accuracy;
 }
 
-@property (nonatomic,readonly) BOOL isTracking;
-@property (nonatomic,retain) NSArray *location;
-@property (nonatomic,readonly) RACSignal *lastKnown;
+@property(nonatomic, readonly) BOOL isTracking;
+@property(nonatomic, retain) NSArray *location;
+@property(nonatomic, readonly) RACSignal *lastKnown;
 
--(void)locationAccuracy:(CLLocationAccuracy)accuracy withDistance:(CLLocationDistance)distance;
+- (void)locationAccuracy:(CLLocationAccuracy)accuracy
+            withDistance:(CLLocationDistance)distance;
 
--(void)enableGPS;
--(void)disableGPS;
+- (void)enableGPS;
+- (void)disableGPS;
 
 @end

--- a/SpatialConnect/SCServiceManager.h
+++ b/SpatialConnect/SCServiceManager.h
@@ -17,12 +17,13 @@
 * under the License.
 ******************************************************************************/
 
-#import <Foundation/Foundation.h>
-#import "SCService.h"
+#import "SCConfigService.h"
 #import "SCDataService.h"
-#import "SCSensorService.h"
 #import "SCNetworkService.h"
 #import "SCRasterService.h"
+#import "SCSensorService.h"
+#import "SCService.h"
+#import <Foundation/Foundation.h>
 
 @interface SCServiceManager : NSObject
 
@@ -31,6 +32,7 @@
 @property(nonatomic, readonly, strong) SCNetworkService *networkService;
 @property(nonatomic, readonly, strong) SCSensorService *sensorService;
 @property(nonatomic, readonly, strong) SCRasterService *rasterService;
+@property(nonatomic, readonly, strong) SCConfigService *configService;
 
 - (instancetype)initWithFilepath:(NSString *)filepath;
 - (instancetype)initWithFilepaths:(NSArray *)filepaths;

--- a/SpatialConnect/SpatialConnect.m
+++ b/SpatialConnect/SpatialConnect.m
@@ -32,7 +32,7 @@
 
 - (id)init {
   if (self = [super init]) {
-    self.manager = [[SCServiceManager alloc] init]; // TODO sweep common dirs
+    self.manager = [[SCServiceManager alloc] init];
     [self startAssertionHandler];
   }
   return self;


### PR DESCRIPTION
## Status

**READY**
## Description

This is the first step to fully reactive server side data store configurations. This PR allows for the library to load configs asynchronously and will let new events from the server mutate the services' state. 
## Ticket

SPACON-29
## Todos
- [x] Tests
- [x] Documentation
## Steps to Test or Reproduce

Run the unit tests or load an sc config in a sample application

``` sh
git pull --prune
git checkout <feature_branch>
xctool -workspace SpatialConnect.xcworkspace -scheme SpatialConnect -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6 Plus' ONLY_ACTIVE_ARCH=NO test
```
## Impacted Areas in Application

List general components of the application that this PR will affect:
- SCDataService
- SCDataStore

@boundlessgeo/spatial-connect
