### PR TITLE
Adding SCFormFeature to be used for form collection data

### DIFF
--- a/SpatialConnect.xcodeproj/project.pbxproj
+++ b/SpatialConnect.xcodeproj/project.pbxproj
@@ -282,6 +282,8 @@
 		56DC516A1BFC2315002C71B3 /* SpatialConnect.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5649B4931BE27C6A009947EF /* SpatialConnect.framework */; };
 		56DC516D1BFD22AB002C71B3 /* SCServiceStatusEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = 56DC516B1BFD22AB002C71B3 /* SCServiceStatusEvent.h */; };
 		56DC516E1BFD22AB002C71B3 /* SCServiceStatusEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = 56DC516C1BFD22AB002C71B3 /* SCServiceStatusEvent.m */; };
+		56E2F41A1CEE9CB8001CCD86 /* SCFormFeature.h in Headers */ = {isa = PBXBuildFile; fileRef = 56E2F4181CEE9CB8001CCD86 /* SCFormFeature.h */; };
+		56E2F41B1CEE9CB8001CCD86 /* SCFormFeature.m in Sources */ = {isa = PBXBuildFile; fileRef = 56E2F4191CEE9CB8001CCD86 /* SCFormFeature.m */; };
 		56ED69C61CE212FC00843C44 /* remote.scfg in Resources */ = {isa = PBXBuildFile; fileRef = 56ED69C51CE212FC00843C44 /* remote.scfg */; };
 		56ED69C81CE2151000843C44 /* SCConfigServiceTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 56ED69C71CE2151000843C44 /* SCConfigServiceTest.m */; };
 		56F4375A1CA0955200EA1344 /* FMDB.h in Headers */ = {isa = PBXBuildFile; fileRef = 56F4374F1CA0955200EA1344 /* FMDB.h */; };
@@ -598,6 +600,8 @@
 		56DC51681BFC230B002C71B3 /* libPods.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libPods.a; path = "Pods/../build/Debug-iphoneos/libPods.a"; sourceTree = "<group>"; };
 		56DC516B1BFD22AB002C71B3 /* SCServiceStatusEvent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SCServiceStatusEvent.h; sourceTree = "<group>"; };
 		56DC516C1BFD22AB002C71B3 /* SCServiceStatusEvent.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SCServiceStatusEvent.m; sourceTree = "<group>"; };
+		56E2F4181CEE9CB8001CCD86 /* SCFormFeature.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SCFormFeature.h; sourceTree = "<group>"; };
+		56E2F4191CEE9CB8001CCD86 /* SCFormFeature.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SCFormFeature.m; sourceTree = "<group>"; };
 		56ED69C51CE212FC00843C44 /* remote.scfg */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = remote.scfg; sourceTree = "<group>"; };
 		56ED69C71CE2151000843C44 /* SCConfigServiceTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SCConfigServiceTest.m; sourceTree = "<group>"; };
 		56F4374F1CA0955200EA1344 /* FMDB.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FMDB.h; sourceTree = "<group>"; };
@@ -883,6 +887,8 @@
 				563BEC641BE5283800778EDA /* Geometry */,
 				563BEC631BE5283100778EDA /* GeoJSON */,
 				563BEC621BE5282900778EDA /* MapKit */,
+				56E2F4181CEE9CB8001CCD86 /* SCFormFeature.h */,
+				56E2F4191CEE9CB8001CCD86 /* SCFormFeature.m */,
 			);
 			name = SpatialDataType;
 			sourceTree = "<group>";
@@ -1436,6 +1442,7 @@
 				5649B5EB1BE280D6009947EF /* SCMultiPolygon+MapKit.h in Headers */,
 				56CC07951C6E90F700407D4A /* SCGeopackage.h in Headers */,
 				5649B59F1BE280D6009947EF /* SCFilterIn.h in Headers */,
+				56E2F41A1CEE9CB8001CCD86 /* SCFormFeature.h in Headers */,
 				56789C401C32C0AC001B5ABE /* SCSimplePoint.h in Headers */,
 				5649B5C51BE280D6009947EF /* SCJavascriptBridge.h in Headers */,
 				5649B5B21BE280D6009947EF /* SCGeoFilterContains.h in Headers */,
@@ -1731,6 +1738,7 @@
 				5649B5891BE280D6009947EF /* SCComparisonPredicate.m in Sources */,
 				5649B5911BE280D6009947EF /* SCDataStore.m in Sources */,
 				5649B5E61BE280D6009947EF /* SCMultiPoint+MapKit.m in Sources */,
+				56E2F41B1CEE9CB8001CCD86 /* SCFormFeature.m in Sources */,
 				5645C4FB1BED9708006E4128 /* SCMultiPoint+GPKG.m in Sources */,
 				56F437621CA0955200EA1344 /* FMDatabaseAdditions.m in Sources */,
 				5649B5F21BE280D6009947EF /* SCPoint.m in Sources */,

--- a/SpatialConnect/SCDefaultStore.m
+++ b/SpatialConnect/SCDefaultStore.m
@@ -88,8 +88,7 @@
         stringWithFormat:@"http://localhost:8085/form/%d/submit",
                          [[formIds objectForKey:feature.layerId] integerValue]];
     NSURL *url = [NSURL URLWithString:urlStr];
-    SCPoint *p = (SCPoint *)feature;
-    return [sc.networkService postDictRequestAsDict:url body:p.JSONDict];
+    return [sc.networkService postDictRequestAsDict:url body:feature.JSONDict];
   }];
 }
 

--- a/SpatialConnect/SCFormFeature.h
+++ b/SpatialConnect/SCFormFeature.h
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2016 Boundless http://boundlessgeo.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+#import "SCGeometry.h"
+#import "SCSpatialFeature.h"
+
+@interface SCFormFeature : SCSpatialFeature
+
+@property(nonatomic, strong) SCGeometry *geometry;
+
+@end

--- a/SpatialConnect/SCFormFeature.m
+++ b/SpatialConnect/SCFormFeature.m
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2016 Boundless http://boundlessgeo.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+#import "SCFormFeature.h"
+
+@implementation SCFormFeature
+
+@synthesize geometry;
+
+- (NSDictionary *)JSONDict {
+  NSMutableDictionary *dictionary =
+      [NSMutableDictionary dictionaryWithDictionary:[super JSONDict]];
+  dictionary[@"metadata"][@"type"] = @"Form";
+  if (self.geometry) {
+    dictionary[@"geometry"] = [self.geometry JSONDict][@"geometry"];
+  } else {
+    dictionary[@"geometry"] = [NSNull null];
+  }
+  return [NSDictionary dictionaryWithDictionary:dictionary];
+}
+
+@end

--- a/SpatialConnect/SCNetworkService.m
+++ b/SpatialConnect/SCNetworkService.m
@@ -82,7 +82,13 @@
   NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:url];
   request.HTTPMethod = @"POST";
   [request addValue:@"application/json" forHTTPHeaderField:@"Content-Type"];
+  NSError *error;
   request.HTTPBody = dict.JSONData;
+  if (error) {
+    NSLog(@"%@", error.description);
+    return [RACSignal error:error];
+  }
+
   return [[NSURLConnection rac_sendAsynchronousRequest:request]
       reduceEach:^id(NSURLResponse *response, NSData *data) {
         return data;

--- a/SpatialConnect/SCSpatialFeature.h
+++ b/SpatialConnect/SCSpatialFeature.h
@@ -22,6 +22,9 @@
 
 @interface SCSpatialFeature : NSObject
 
+@property(nonatomic) NSArray *location;
+@property(nonatomic) NSString *author;
+@property(nonatomic) NSString *deviceId;
 @property(nonatomic) NSString *identifier;
 @property(nonatomic) NSDate *date;
 @property(nonatomic) NSDate *createdAt;

--- a/SpatialConnect/SCSpatialFeature.m
+++ b/SpatialConnect/SCSpatialFeature.m
@@ -24,6 +24,10 @@
 
 @implementation SCSpatialFeature
 
+@synthesize location;
+@synthesize author;
+@synthesize deviceId;
+@synthesize createdAt;
 @synthesize identifier = _identifier;
 @synthesize date;
 @synthesize properties = _properties;
@@ -34,6 +38,7 @@
 - (id)init {
   if (self = [super init]) {
     _properties = [NSMutableDictionary new];
+    createdAt = [NSDate dateWithTimeIntervalSinceNow:0];
   }
   return self;
 }
@@ -61,6 +66,7 @@
 
 - (NSDictionary *)JSONDict {
   NSMutableDictionary *dict = [NSMutableDictionary new];
+  dict[@"type"] = @"Feature";
   if (self.identifier) {
     dict[@"id"] = self.key.encodedCompositeKey;
   }
@@ -69,7 +75,21 @@
   } else {
     dict[@"properties"] = [NSNull null];
   }
+  dict[@"metadata"] = [NSMutableDictionary new];
+  NSDateFormatter *df = [NSDateFormatter new];
+  [df setDateFormat:@"yyyy-MM-dd HH:mm:ss zzz"];
+  dict[@"metadata"][@"created_at"] = [df stringFromDate:self.createdAt];
+  dict[@"metadata"][@"client"] = [self appleIFV];
   return [NSDictionary dictionaryWithDictionary:dict];
+}
+
+- (NSString *)appleIFV {
+  if (NSClassFromString(@"UIDevice") &&
+      [UIDevice instancesRespondToSelector:@selector(identifierForVendor)]) {
+    // only available in iOS >= 6.0
+    return [[UIDevice currentDevice].identifierForVendor UUIDString];
+  }
+  return nil;
 }
 
 @end

--- a/SpatialConnectTests/SCNetworkServiceTest.m
+++ b/SpatialConnectTests/SCNetworkServiceTest.m
@@ -14,6 +14,7 @@
  * limitations under the License
  */
 
+#import "SCFormFeature.h"
 #import "SCGeopackageHelper.h"
 #import "SCNetworkService.h"
 #import "SCPoint.h"
@@ -67,11 +68,13 @@
   NSArray *arr = [self.sc.dataService defaultStoreLayers];
   XCTAssertNotNil(arr);
   SCPoint *p = [[SCPoint alloc] initWithCoordinateArray:@[ @(22.3), @(56.2) ]];
+  SCFormFeature *f = [[SCFormFeature alloc] init];
   GeopackageStore *ds = self.sc.dataService.defaultStore;
-  p.layerId = @"one";
-  p.storeId = ds.storeId;
-  [p.properties setObject:@"Joe Jackson" forKey:@"Father"];
-  [[ds create:p] subscribeError:^(NSError *error) {
+  f.layerId = @"one";
+  f.storeId = ds.storeId;
+  f.geometry = p;
+  [f.properties setObject:@"Joe Jackson" forKey:@"Father"];
+  [[ds create:f] subscribeError:^(NSError *error) {
     [expect fulfill];
   }
       completed:^{


### PR DESCRIPTION
## Status

**READY**
## Description

Modifies the JSON representation for submission over HTTP for forms to use a metadata type and add several fields to the Metadata property. 

```
{
  "type": "Feature",
  "id": "REVGQVVMVF9TVE9SRQ==.b25l.OQ==",
  "metadata": {
    "type": "Form",
    "client": "F3F0C46B-64BA-4A72-8958-EF20F5144FE2",
    "created_at": "2016-05-19 21:32:59 CDT"
  },
  "geometry": {
    "type": "Point",
    "coordinates": [
      22.3,
      56.2,
      0
    ]
  },
  "properties": {
    "Father": "Joe Jackson"
  }
}
```
## Todos
- [x] Tests
- [x] Documentation
## Impacted Areas in Application

List general components of the application that this PR will affect:
- SCSpatialFeature and feature representations as JSON.

@boundlessgeo/spatial-connect
