### PR TITLE
Adding Registration of Device and a Blocking Post HTTP request

### DIFF
--- a/SpatialConnect/SCDefaultStore.m
+++ b/SpatialConnect/SCDefaultStore.m
@@ -84,9 +84,9 @@
           return NO;
         }
       }] flattenMap:^RACStream *(id value) {
+    NSInteger formid = [[formIds objectForKey:feature.layerId] integerValue];
     NSString *urlStr = [NSString
-        stringWithFormat:@"http://localhost:8085/form/%d/submit",
-                         [[formIds objectForKey:feature.layerId] integerValue]];
+        stringWithFormat:@"http://localhost:8085/form/%d/submit", formid];
     NSURL *url = [NSURL URLWithString:urlStr];
     return [sc.networkService postDictRequestAsDict:url body:feature.JSONDict];
   }];

--- a/SpatialConnect/SCNetworkService.h
+++ b/SpatialConnect/SCNetworkService.h
@@ -50,6 +50,8 @@
 - (RACSignal *)postRequestAsData:(NSURL *)url body:(NSData *)data;
 
 - (RACSignal *)postDictRequestAsDict:(NSURL *)url body:(NSDictionary *)dict;
+- (NSDictionary *)postDictRequestAsDictBLOCKING:(NSURL *)url
+                                           body:(NSDictionary *)dict;
 
 /*!
  *  @brief Basic Auth for a url

--- a/SpatialConnect/SCNetworkService.m
+++ b/SpatialConnect/SCNetworkService.m
@@ -95,6 +95,20 @@
       }];
 }
 
+- (NSDictionary *)postDictRequestAsDictBLOCKING:(NSURL *)url
+                                           body:(NSDictionary *)dict {
+  NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:url];
+  request.HTTPMethod = @"POST";
+  [request addValue:@"application/json" forHTTPHeaderField:@"Content-Type"];
+  NSError *err;
+  NSURLResponse *response;
+  request.HTTPBody = dict.JSONData;
+  NSData *data = [NSURLConnection sendSynchronousRequest:request
+                                       returningResponse:&response
+                                                   error:&err];
+  return [[JSONDecoder decoder] objectWithData:data];
+}
+
 - (void)start {
 }
 

--- a/SpatialConnect/SCSpatialFeature.m
+++ b/SpatialConnect/SCSpatialFeature.m
@@ -79,17 +79,9 @@
   NSDateFormatter *df = [NSDateFormatter new];
   [df setDateFormat:@"yyyy-MM-dd HH:mm:ss zzz"];
   dict[@"metadata"][@"created_at"] = [df stringFromDate:self.createdAt];
-  dict[@"metadata"][@"client"] = [self appleIFV];
+  dict[@"metadata"][@"client"] =
+      [[NSUserDefaults standardUserDefaults] stringForKey:@"UNIQUE_ID"];
   return [NSDictionary dictionaryWithDictionary:dict];
-}
-
-- (NSString *)appleIFV {
-  if (NSClassFromString(@"UIDevice") &&
-      [UIDevice instancesRespondToSelector:@selector(identifierForVendor)]) {
-    // only available in iOS >= 6.0
-    return [[UIDevice currentDevice].identifierForVendor UUIDString];
-  }
-  return nil;
 }
 
 @end

--- a/SpatialConnectTests/remote.scfg
+++ b/SpatialConnectTests/remote.scfg
@@ -1,3 +1,3 @@
 {
-"remote":"http://localhost:8085/config/1"
+"remote":"http://localhost:8085/config"
 }


### PR DESCRIPTION
## Status

**READY**
## Description

The device must register with a unique install/device identifier in the config service in order to submit form posts. The server is also now a single config instance. The device identifier is cached and sent in the payload `metadata.client`.
## Todos
- [x] Tests
- [x] Documentation
## Impacted Areas in Application

List general components of the application that this PR will affect:
- SCFormFeature, SCConfigService `start`

@boundlessgeo/spatial-connect
