### PR TITLE
fix geojsonstore type

### DIFF
--- a/SpatialConnect/GeoJSONStore.m
+++ b/SpatialConnect/GeoJSONStore.m
@@ -71,7 +71,7 @@ const NSString *kSTORE_NAME = @"GeoJSONStore";
   adapter.storeId = self.storeId;
 }
 
-- (NSString *)type {
+- (NSString *)storeType {
   return [NSString stringWithFormat:@"%@", kTYPE];
 }
 


### PR DESCRIPTION
## Status

**READY**
## Description

Fixes GeoJSONStore type
## Todos
- [x] Tests
- [x] Documentation
- [x] License

``` sh
git fetch --all
git checkout <feature_branch> 
xctool -workspace SpatialConnect.xcworkspace -scheme SpatialConnect -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6 Plus' ONLY_ACTIVE_ARCH=NO test
```

@boundlessgeo/spatial-connect
