### PR TITLE
Adding multi layer WFS query

### DIFF
--- a/SpatialConnect/SCDataService.m
+++ b/SpatialConnect/SCDataService.m
@@ -65,10 +65,11 @@ NSString *const kSERVICENAME = @"DATASERVICE";
 }
 
 - (void)setupDefaultStore {
-  SCStoreConfig *config = [[SCStoreConfig alloc] init];
-  config.uniqueid = @"DEFAULT_STORE";
-  config.uri = @"spacon_default_store.db";
-  config.name = @"DEFAULT_STORE";
+  SCStoreConfig *config = [[SCStoreConfig alloc] initWithDictionary:@{
+    @"id" : @"DEFAULT_STORE",
+    @"uri" : @"spacon_default_store.db",
+    @"name" : @"DEFAULT_STORE"
+  }];
   _defaultStore = [[SCDefaultStore alloc] initWithStoreConfig:config];
   defaultStoreForms = [NSMutableArray new];
   [_stores setObject:_defaultStore forKey:config.uniqueid];
@@ -78,7 +79,7 @@ NSString *const kSERVICENAME = @"DATASERVICE";
   return [self.defaultStore layerList];
 }
 
-- (NSArray*)defaultStoreForms {
+- (NSArray *)defaultStoreForms {
   return [NSArray arrayWithArray:defaultStoreForms];
 }
 
@@ -107,13 +108,16 @@ NSString *const kSERVICENAME = @"DATASERVICE";
 
 - (RACSignal *)storeStarted:(NSString *)storeId {
   if ([[self storeByIdentifier:storeId] status] == SC_DATASTORE_RUNNING) {
-    SCStoreStatusEvent *evt = [[SCStoreStatusEvent alloc] initWithEvent:SC_DATASTORE_EVT_STARTED andStoreId:storeId];
+    SCStoreStatusEvent *evt =
+        [[SCStoreStatusEvent alloc] initWithEvent:SC_DATASTORE_EVT_STARTED
+                                       andStoreId:storeId];
     return [RACSignal return:evt];
   }
   RACMulticastConnection *rmcc = self.storeEvents;
   [rmcc connect];
   return [[rmcc.signal filter:^BOOL(SCStoreStatusEvent *evt) {
-    if (evt.status == SC_DATASTORE_EVT_STARTED && [evt.storeId isEqualToString:storeId]) {
+    if (evt.status == SC_DATASTORE_EVT_STARTED &&
+        [evt.storeId isEqualToString:storeId]) {
       return YES;
     }
     return NO;
@@ -138,8 +142,7 @@ NSString *const kSERVICENAME = @"DATASERVICE";
           [NSString stringWithFormat:@"Store %@ with key:%@ id:%@ "
                                      @"was not started. Make sure the store "
                                      @"conforms to the SCDataStoreLifeCycle",
-                                     store.name, store.key,
-                                     store.storeId]);
+                                     store.name, store.key, store.storeId]);
   }
 }
 

--- a/SpatialConnect/SCDataStore.h
+++ b/SpatialConnect/SCDataStore.h
@@ -46,7 +46,7 @@ typedef NS_ENUM(NSInteger, SCDataStorePermission) {
 @property(readonly) NSString *storeVersion;
 @property(readonly) NSString *storeType;
 @property(readonly) NSString *key;
-@property(readonly) NSString *defaultLayerName;
+@property(readonly) NSArray *defaultLayers;
 @property SCDataStoreStatus status;
 @property SCDataStorePermission permission;
 

--- a/SpatialConnect/SCDataStore.m
+++ b/SpatialConnect/SCDataStore.m
@@ -24,13 +24,13 @@
 @property(readwrite, nonatomic, strong) NSString *storeVersion;
 @property(readwrite, nonatomic, strong) NSString *storeType;
 @property(readwrite, nonatomic, strong) NSArray *layerList;
-@property(readwrite, nonatomic, strong) NSString *defaultLayerName;
+@property(readwrite, nonatomic, strong) NSArray *defaultLayers;
 @end
 
 @implementation SCDataStore
 
 @synthesize name;
-@synthesize defaultLayerName = _defaultLayerName;
+@synthesize defaultLayers = _defaultLayers;
 @synthesize key = _key;
 @synthesize status, permission;
 @synthesize storeVersion = _storeVersion;
@@ -54,7 +54,7 @@
   }
   self.storeId = config.uniqueid;
   self.name = config.name;
-  self.defaultLayerName = config.defaultLayer;
+  self.defaultLayers = config.defaultLayers;
   return self;
 }
 
@@ -82,7 +82,7 @@
     @"type" : self.storeType,
     @"version" : self.storeVersion,
     @"key" : self.key,
-    @"default_layer" : self.defaultLayerName
+    @"default_layers" : self.defaultLayers
   };
 }
 

--- a/SpatialConnect/SCSpatialStore.h
+++ b/SpatialConnect/SCSpatialStore.h
@@ -63,12 +63,12 @@
 - (RACSignal *) delete:(SCKeyTuple *)key;
 
 /**
- *  Default layer to be used when no layer is present in
- *  SCSpatialFeature's layerId ivar
+ *  Default layers for searching when no layers
+ *  are present in SCQueryFilter
  *
  *  @return string representing layer name
  */
-- (NSString *)defaultLayer;
+- (NSArray *)defaultLayers;
 
 /**
  *  List of layers in the store

--- a/SpatialConnect/SCStoreConfig.h
+++ b/SpatialConnect/SCStoreConfig.h
@@ -23,13 +23,13 @@
 @interface SCStoreConfig : NSObject {
 }
 
-@property(nonatomic, weak) NSString *type;
-@property(nonatomic, weak) NSString *version;
-@property(nonatomic, weak) NSString *uri;
-@property(nonatomic, weak) NSString *uniqueid;
-@property BOOL isMainBundle;
-@property(nonatomic, weak) NSString *name;
-@property(nonatomic) NSString *defaultLayer;
+@property(nonatomic, weak, readonly) NSString *type;
+@property(nonatomic, weak, readonly) NSString *version;
+@property(nonatomic, weak, readonly) NSString *uri;
+@property(nonatomic, weak, readonly) NSString *uniqueid;
+@property(readonly) BOOL isMainBundle;
+@property(nonatomic, weak, readonly) NSString *name;
+@property(nonatomic, readonly) NSArray *defaultLayers;
 
 - (id)initWithDictionary:(NSDictionary *)dict;
 

--- a/SpatialConnect/SCStoreConfig.m
+++ b/SpatialConnect/SCStoreConfig.m
@@ -17,31 +17,32 @@
 * under the License.
 ******************************************************************************/
 #import "SCDataService.h"
-#import "SCStoreConfig.h"
 #import "SCMessage.h"
+#import "SCStoreConfig.h"
 
 @implementation SCStoreConfig
 
-@synthesize type;
-@synthesize version;
-@synthesize uniqueid;
-@synthesize uri;
-@synthesize isMainBundle;
+@synthesize type = _type;
+@synthesize version = _version;
+@synthesize uniqueid = _uniqueid;
+@synthesize uri = _uri;
+@synthesize isMainBundle = _isMainBundle;
+@synthesize defaultLayers = _defaultLayers;
+@synthesize name = _name;
 
 - (id)initWithDictionary:(NSDictionary *)dict {
   self = [super init];
   if (self) {
-    self.type = dict[@"store_type"];
-    self.version = dict[@"version"];
-    self.uniqueid =
-        dict[@"id"] == nil ? [[NSUUID UUID] UUIDString] : dict[@"id"];
-    self.uri = dict[@"uri"];
-    self.isMainBundle = [dict[@"isMainBundle"] boolValue];
+    _type = dict[@"store_type"];
+    _version = dict[@"version"];
+    _uniqueid = dict[@"id"] == nil ? [[NSUUID UUID] UUIDString] : dict[@"id"];
+    _uri = dict[@"uri"];
+    _isMainBundle = [dict[@"isMainBundle"] boolValue];
     if (!self.isMainBundle) {
-      self.isMainBundle = NO;
+      _isMainBundle = NO;
     }
-    self.defaultLayer = dict[@"default_layer"];
-    self.name = dict[@"name"];
+    _defaultLayers = dict[@"default_layers"];
+    _name = dict[@"name"];
   }
   return self;
 }

--- a/SpatialConnectTests/SCGeopackageCreateTest.m
+++ b/SpatialConnectTests/SCGeopackageCreateTest.m
@@ -46,7 +46,7 @@
       flattenMap:^RACStream *(GeopackageStore *ds) {
         SCPoint *p =
             [[SCPoint alloc] initWithCoordinateArray:@[ @(32.3), @(43.1) ]];
-        p.layerId = ds.defaultLayerName;
+        p.layerId = ds.defaultLayers[0];
         return [ds create:p];
       }] subscribeError:^(NSError *error) {
     NSLog(@"%@", error.description);

--- a/SpatialConnectTests/SCGeopackageLoadTest.m
+++ b/SpatialConnectTests/SCGeopackageLoadTest.m
@@ -49,7 +49,6 @@
   [[SCGeopackageHelper loadGPKGDataStore:self.sc]
       subscribeNext:^(SCDataStore *ds) {
         if (ds) {
-          XCTAssertNotNil(ds.defaultLayerName, @"Layer Name shall be set");
           XCTAssertNotNil(ds.layerList, @"Layer list as array");
           XCTAssertNoThrow([sc stopAllServices]);
         } else {

--- a/SpatialConnectTests/WFSDataStoreTest.m
+++ b/SpatialConnectTests/WFSDataStoreTest.m
@@ -18,6 +18,7 @@
  ******************************************************************************/
 
 #import "SCDataStore.h"
+#import "SCGeoFilterContains.h"
 #import "SCGeopackageGeometryExtensions.h"
 #import "SCGeopackageHelper.h"
 #import "SCStoreStatusEvent.h"
@@ -25,7 +26,6 @@
 #import "SpatialConnectHelper.h"
 #import <ReactiveCocoa/ReactiveCocoa.h>
 #import <XCTest/XCTest.h>
-#import "SCGeoFilterContains.h"
 
 @interface WFSDataStoreTest : XCTestCase
 @property(nonatomic) SpatialConnect *sc;
@@ -45,23 +45,26 @@
 }
 
 - (void)testWFSLayerList {
-  XCTestExpectation *expect = [self expectationWithDescription:@"GetCapabilities"];
+  XCTestExpectation *expect =
+      [self expectationWithDescription:@"GetCapabilities"];
 
-  [[SpatialConnectHelper loadWFSGDataStore:self.sc
-                                   storeId:@"0f193979-b871-47cd-b60d-e271d6504359"]
-   subscribeNext:^(SCDataStore *ds) {
-     if (ds) {
-       XCTAssertNotNil(ds.layerList, @"Layer list as array");
-       XCTAssertNoThrow([sc stopAllServices]);
-     } else {
-       XCTAssert(NO, @"Store is nil");
-     }
-     [expect fulfill];
-   }
-   error:^(NSError *error) {
-     XCTAssert(NO, @"Error retrieving store");
-     [expect fulfill];
-   }];
+  [[SpatialConnectHelper
+      loadWFSGDataStore:self.sc
+                storeId:@"0f193979-b871-47cd-b60d-e271d6504359"]
+      subscribeNext:^(SCDataStore *ds) {
+        if (ds) {
+          NSArray *list = ds.layerList;
+          XCTAssertNotNil(list, @"Layer list as array");
+          XCTAssertNoThrow([sc stopAllServices]);
+        } else {
+          XCTAssert(NO, @"Store is nil");
+        }
+        [expect fulfill];
+      }
+      error:^(NSError *error) {
+        XCTAssert(NO, @"Error retrieving store");
+        [expect fulfill];
+      }];
 
   [sc startAllServices];
   [self waitForExpectationsWithTimeout:12.0 handler:nil];
@@ -70,36 +73,89 @@
 - (void)testWFSLayerQuery {
   XCTestExpectation *expect = [self expectationWithDescription:@"GetFeature"];
   __block BOOL hasFeatures = NO;
-  [[[SpatialConnectHelper loadWFSGDataStore:self.sc
-                                   storeId:@"0f193979-b871-47cd-b60d-e271d6504359"]
-   flattenMap:^RACStream *(SCDataStore *ds) {
-     if (ds) {
-       NSString *defaultLayer = ds.defaultLayerName;
-       XCTAssertNotNil(defaultLayer, @"Layer Name shall be set");
-       XCTAssertNotNil(ds.layerList, @"Layer list as array");
-       SCQueryFilter *filter = [[SCQueryFilter alloc] init];
-       SCBoundingBox *bbox = [[SCBoundingBox alloc] initWithCoords:@[@(-124.07438528127528),@(42.922397667217076),@(-64.76484934151024),@(58.79784328722645)]];
-       SCGeoFilterContains *gfc = [[SCGeoFilterContains alloc] initWithBBOX:bbox];
-       SCPredicate *predicate = [[SCPredicate alloc] initWithFilter:gfc];
-       [filter addPredicate:predicate];
-       id<SCSpatialStore> s = (id<SCSpatialStore>)ds;
-       return [s query:filter];
-     } else {
-       XCTAssert(NO, @"Store is nil");
-     }
-     [expect fulfill];
-   }]
-   subscribeNext:^(SCSpatialFeature *f) {
-     XCTAssertNotNil(f,@"Feature should be alloced");
-     hasFeatures = YES;
-   } error:^(NSError *error) {
-     XCTFail(@"%@",[error description]);
-   } completed:^{
-     XCTAssertNoThrow([sc stopAllServices]);
-     if (hasFeatures) {
-       [expect fulfill];
-     }
-   }];
+  [[[SpatialConnectHelper
+      loadWFSGDataStore:self.sc
+                storeId:@"0f193979-b871-47cd-b60d-e271d6504359"]
+      flattenMap:^RACStream *(SCDataStore *ds) {
+        if (ds) {
+          XCTAssertNotNil(ds.layerList, @"Layer list as array");
+          SCQueryFilter *filter = [[SCQueryFilter alloc] init];
+          [filter
+              addLayerIds:[ds.layerList subarrayWithRange:NSMakeRange(0, 1)]];
+          SCBoundingBox *bbox = [[SCBoundingBox alloc] initWithCoords:@[
+            @(-124.07438528127528),
+            @(42.922397667217076),
+            @(-64.76484934151024),
+            @(58.79784328722645)
+          ]];
+          SCGeoFilterContains *gfc =
+              [[SCGeoFilterContains alloc] initWithBBOX:bbox];
+          SCPredicate *predicate = [[SCPredicate alloc] initWithFilter:gfc];
+          [filter addPredicate:predicate];
+          id<SCSpatialStore> s = (id<SCSpatialStore>)ds;
+          return [s query:filter];
+        } else {
+          XCTAssert(NO, @"Store is nil");
+        }
+        [expect fulfill];
+      }] subscribeNext:^(SCSpatialFeature *f) {
+    XCTAssertNotNil(f, @"Feature should be alloced");
+    hasFeatures = YES;
+  }
+      error:^(NSError *error) {
+        XCTFail(@"%@", [error description]);
+      }
+      completed:^{
+        XCTAssertNoThrow([sc stopAllServices]);
+        if (hasFeatures) {
+          [expect fulfill];
+        }
+      }];
+
+  [sc startAllServices];
+  [self waitForExpectationsWithTimeout:15.0 handler:nil];
+}
+
+- (void)testWFSMultiLayerQuery {
+  XCTestExpectation *expect = [self expectationWithDescription:@"GetFeature"];
+  __block BOOL hasFeatures = NO;
+  [[[SpatialConnectHelper
+      loadWFSGDataStore:self.sc
+                storeId:@"0f193979-b871-47cd-b60d-e271d6504359"]
+      flattenMap:^RACStream *(SCDataStore *ds) {
+        if (ds) {
+          SCQueryFilter *filter = [[SCQueryFilter alloc] init];
+          [filter
+              addLayerIds:[ds.layerList subarrayWithRange:NSMakeRange(3, 3)]];
+          SCBoundingBox *bbox = [[SCBoundingBox alloc] initWithCoords:@[
+            @(-124.07438528127528),
+            @(42.922397667217076),
+            @(-64.76484934151024),
+            @(58.79784328722645)
+          ]];
+          SCGeoFilterContains *gfc =
+              [[SCGeoFilterContains alloc] initWithBBOX:bbox];
+          SCPredicate *predicate = [[SCPredicate alloc] initWithFilter:gfc];
+          [filter addPredicate:predicate];
+          id<SCSpatialStore> s = (id<SCSpatialStore>)ds;
+          return [s query:filter];
+        } else {
+          XCTAssert(NO, @"Store is nil");
+        }
+        [expect fulfill];
+      }] subscribeNext:^(SCSpatialFeature *f) {
+    XCTAssertNotNil(f, @"Feature should be alloced");
+    hasFeatures = YES;
+  }
+      error:^(NSError *error) {
+        XCTFail(@"%@", [error description]);
+      }
+      completed:^{
+        XCTAssertNoThrow([sc stopAllServices]);
+        if (hasFeatures) {
+          [expect fulfill];
+        }
+      }];
 
   [sc startAllServices];
   [self waitForExpectationsWithTimeout:15.0 handler:nil];


### PR DESCRIPTION
## Status

**READY**
## JIRA Ticket

SPACON-181
## Description

Adds the ability to query more than one WFS layer. If the id contains a layer name, it will set it as the SpatialFeature's layerId ivar
## Todos
- [x] Tests
- [x] Documentation
- [x] License
## Steps to Test or Reproduce

Outline the steps to test or reproduce the PR here.

``` sh
git fetch --all
git checkout <feature_branch> 
xctool -workspace SpatialConnect.xcworkspace -scheme SpatialConnect -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6 Plus' ONLY_ACTIVE_ARCH=NO test
```

@boundlessgeo/spatial-connect
