### PR TITLE
Add defaultStoreFormsDictionary method to Data Service

### DIFF
--- a/SpatialConnect/SCDataService.h
+++ b/SpatialConnect/SCDataService.h
@@ -59,6 +59,7 @@ typedef NS_ENUM(NSUInteger, SCActionDataService) {
 - (NSArray *)storeList;
 - (NSArray *)activeStoreList;
 - (NSArray *)activeStoreListDictionary;
+- (NSArray *)defaultStoreFormsDictionary;
 - (NSDictionary *)storeByIdAsDictionary:(NSString *)storeId;
 - (NSArray *)storesByProtocol:(Protocol *)protocol;
 - (NSArray *)storesByProtocol:(Protocol *)protocol onlyRunning:(BOOL)running;

--- a/SpatialConnect/SCDataService.m
+++ b/SpatialConnect/SCDataService.m
@@ -249,6 +249,15 @@ NSString *const kSERVICENAME = @"DATASERVICE";
   return [NSArray arrayWithArray:arr];
 }
 
+- (NSArray *)defaultStoreFormsDictionary {
+  NSMutableArray *arr = [[NSMutableArray alloc] init];
+  [[self defaultStoreForms] enumerateKeysAndObjectsUsingBlock:^(
+                                                       id key, SCFormConfig *f, BOOL *stop) {
+    [arr addObject:[f JSONDict]];
+  }];
+  return [NSArray arrayWithArray:arr];
+}
+
 - (NSDictionary *)storeByIdAsDictionary:(NSString *)storeId {
   SCDataStore *ds = [self storeByIdentifier:storeId];
   NSMutableDictionary *store = [[NSMutableDictionary alloc] init];

--- a/SpatialConnect/SCJavascriptBridgeAPI.m
+++ b/SpatialConnect/SCJavascriptBridgeAPI.m
@@ -104,12 +104,8 @@
 
 - (void)formList:(id<RACSubscriber>)subscriber {
   NSArray *arr =
-      [[[SpatialConnect sharedInstance] dataService] defaultStoreForms];
-  NSMutableArray *forms = [NSMutableArray array];
-  for (id formConfig in arr) {
-    [forms addObject:[formConfig JSONDict]];
-  }
-  [subscriber sendNext:@{ @"forms" : forms }];
+      [[[SpatialConnect sharedInstance] dataService] defaultStoreFormsDictionary];
+  [subscriber sendNext:@{ @"forms" : arr }];
   [subscriber sendCompleted];
 }
 


### PR DESCRIPTION
## Status

**READY**
## Description
- Add defaultStoreFormsDictionary method to Data Service. Used in bridge to retrieve forms as array of json dicts
## Todos
- [x] Tests
- [x] Documentation
- [x] License

``` sh
git fetch --all
git checkout <feature_branch> 
xctool -workspace SpatialConnect.xcworkspace -scheme SpatialConnect -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6 Plus' ONLY_ACTIVE_ARCH=NO test
```

@boundlessgeo/spatial-connect
