### PR TITLE
Change FormConfig to form_key and form_label

### DIFF
--- a/SpatialConnect/SCFormConfig.m
+++ b/SpatialConnect/SCFormConfig.m
@@ -129,8 +129,8 @@
 
 - (NSDictionary *)JSONDict {
   NSMutableDictionary *dict = [NSMutableDictionary new];
-  dict[@"layer_name"] = self.key;
-  dict[@"display_name"] = self.label;
+  dict[@"form_key"] = self.key;
+  dict[@"form_label"] = self.label;
   dict[@"version"] = @(self.version);
   dict[@"fields"] = self.fields;
   dict[@"id"] = @(self.identifier);


### PR DESCRIPTION
## Status

**READY**
## Description

Form Config now has `form_key` and `form_label` everywhere, instead of layer_name and display_name.
