### PR TITLE
Retrieve storeId and layerId from feature metadata for updateFeature

### DIFF
--- a/SpatialConnect/SCJavascriptBridgeAPI.m
+++ b/SpatialConnect/SCJavascriptBridgeAPI.m
@@ -216,20 +216,22 @@
   }
 }
 
+
 - (void)updateFeature:(NSDictionary *)value
    responseSubscriber:(id<RACSubscriber>)subscriber {
   NSDictionary *geoJsonDict = [value objectForKey:@"feature"];
-  NSString *featureId = [geoJsonDict objectForKey:@"id"];
-  SCKeyTuple *key = [SCKeyTuple tupleFromEncodedCompositeKey:featureId];
+  NSDictionary *metadata = [geoJsonDict objectForKey:@"metadata"];
+  NSString *storeId = [metadata objectForKey:@"storeId"];
+  NSString *layerId = [metadata objectForKey:@"layerId"];
   SCDataStore *store = [[[SpatialConnect sharedInstance] dataService]
-      storeByIdentifier:key.storeId];
+      storeByIdentifier:storeId];
   if (store == nil) {
     store = [[[SpatialConnect sharedInstance] dataService] defaultStore];
   }
   if ([store conformsToProtocol:@protocol(SCSpatialStore)]) {
     id<SCSpatialStore> s = (id<SCSpatialStore>)store;
     SCSpatialFeature *feat = [SCGeoJSON parseDict:geoJsonDict];
-    feat.layerId = key.layerId;
+    feat.layerId = layerId;
     [[s update:feat] subscribeError:^(NSError *error) {
       NSError *err =
           [NSError errorWithDomain:SCJavascriptBridgeErrorDomain


### PR DESCRIPTION
## Status

**READY**
## JIRA Ticket

SPACON-194
## Description
- Features may not have a store.layer.feature id, so `tupleFromEncodedCompositeKey` will fail
- Features should have storeId and layerId in their metadata property
## Todos
- [x] Tests
- [x] Documentation
- [x] License
## Steps to Test or Reproduce

``` sh
git fetch --all
git checkout develop
xctool -workspace SpatialConnect.xcworkspace -scheme SpatialConnect -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6 Plus' ONLY_ACTIVE_ARCH=NO test
```

@boundlessgeo/spatial-connect
