### PR TITLE
Support all geometry types for Geopackage queries

### DIFF
--- a/SpatialConnect/SCGpkgFeatureSource.m
+++ b/SpatialConnect/SCGpkgFeatureSource.m
@@ -70,6 +70,20 @@
   }];
 }
 
+- (Boolean)isGeomCol:(NSString *)t {
+  NSArray *types = [NSArray arrayWithObjects:
+                    @"GEOMETRY",
+                    @"POINT",
+                    @"LINESTRING",
+                    @"POLYGON",
+                    @"MULTIPOINT",
+                    @"MULTILINESTRING",
+                    @"MULTIPOLYGON",
+                    @"GEOMETRYCOLLECTION", nil];
+
+  return [types containsObject: [t uppercaseString]];
+}
+
 - (void)defineTable {
 
   [self.pool inDatabase:^(FMDatabase *db) {
@@ -81,7 +95,7 @@
         self.pkColName = [rs stringForColumn:@"name"];
       }
       NSString *t = [rs stringForColumn:@"type"];
-      if ([t containsString:@"Geometry"]) {
+      if ([self isGeomCol:t]) {
         self.geomColName = [rs stringForColumn:@"name"];
         [cols setObject:@(GEOMETRY) forKey:colName];
       } else if ([t containsString:@"INTEGER"]) {


### PR DESCRIPTION
## Status

**READY**
## Description

Allows all geometry types supported by geopackage to be queried
## Todos
- [x] Tests
- [x] Documentation
- [x] License
## Steps to Test or Reproduce

``` sh
git fetch --all
git checkout <feature_branch> 
xctool -workspace SpatialConnect.xcworkspace -scheme SpatialConnect -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6 Plus' ONLY_ACTIVE_ARCH=NO test
```

@boundlessgeo/spatial-connect
