### PR TITLE
Load geojson file from main bundle + catch missing file errors

### DIFF
--- a/SpatialConnect.xcodeproj/project.pbxproj
+++ b/SpatialConnect.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		542E9B931D6F4442007AB0ED /* SCGeoJSONStoreTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 542E9B921D6F4442007AB0ED /* SCGeoJSONStoreTest.m */; };
 		546D08911D2462E200EBB95A /* SCRCTBridge.h in Headers */ = {isa = PBXBuildFile; fileRef = 546D088F1D2462E200EBB95A /* SCRCTBridge.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		546D08921D2462E200EBB95A /* SCRCTBridge.m in Sources */ = {isa = PBXBuildFile; fileRef = 546D08901D2462E200EBB95A /* SCRCTBridge.m */; };
 		560A71221BE8457C00CE473F /* SCStoreStatusEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = 560A71201BE8457C00CE473F /* SCStoreStatusEvent.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -365,6 +366,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		542E9B921D6F4442007AB0ED /* SCGeoJSONStoreTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SCGeoJSONStoreTest.m; sourceTree = "<group>"; };
 		546D088F1D2462E200EBB95A /* SCRCTBridge.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SCRCTBridge.h; sourceTree = "<group>"; };
 		546D08901D2462E200EBB95A /* SCRCTBridge.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SCRCTBridge.m; sourceTree = "<group>"; };
 		560A71201BE8457C00CE473F /* SCStoreStatusEvent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SCStoreStatusEvent.h; sourceTree = "<group>"; };
@@ -1427,6 +1429,7 @@
 			children = (
 				5649B4B51BE28079009947EF /* SCGeoJSONParserTest.m */,
 				5649B4B61BE28079009947EF /* SCGeoJSONWriterTest.m */,
+				542E9B921D6F4442007AB0ED /* SCGeoJSONStoreTest.m */,
 			);
 			name = GeoJSON;
 			sourceTree = "<group>";
@@ -2038,6 +2041,7 @@
 				5649B4CA1BE28079009947EF /* SCGeoJSONParserTest.m in Sources */,
 				56D5AD2B1D59309A00597300 /* SCLocationTest.m in Sources */,
 				5649B4D51BE28079009947EF /* SpatialConnectHelper.m in Sources */,
+				542E9B931D6F4442007AB0ED /* SCGeoJSONStoreTest.m in Sources */,
 				5649B4D41BE28079009947EF /* SpatialConnectAutoConfigTest.m in Sources */,
 				56FB3F561CF8AADE00C3DA4B /* SCFormTest.m in Sources */,
 				5649B4CC1BE28079009947EF /* SCGeometryHelper.m in Sources */,

--- a/SpatialConnect/GeoJSONAdapter.h
+++ b/SpatialConnect/GeoJSONAdapter.h
@@ -33,7 +33,7 @@
 @property(nonatomic, strong) SCStyle *defaultStyle;
 @property(nonatomic, strong) NSString *storeId;
 
-- (void)connect;
+- (Boolean)connect;
 - (id)initWithFilePath:(NSString *)filepath;
 - (RACSignal *)query:(SCQueryFilter *)filter;
 - (RACSignal *)create:(SCSpatialFeature *)feature;

--- a/SpatialConnect/GeoJSONAdapter.h
+++ b/SpatialConnect/GeoJSONAdapter.h
@@ -21,6 +21,7 @@
 #import "SCGeometry.h"
 #import "SCQueryFilter.h"
 #import "SCSpatialFeature.h"
+#import "SCStoreConfig.h"
 #import "SCStyle.h"
 #import <Foundation/Foundation.h>
 
@@ -32,9 +33,11 @@
 @property GeoJSONStorageConnector *connector;
 @property(nonatomic, strong) SCStyle *defaultStyle;
 @property(nonatomic, strong) NSString *storeId;
+@property(readonly, nonatomic, strong) NSString *uri;
 
-- (Boolean)connect;
+- (RACSignal *)connect;
 - (id)initWithFilePath:(NSString *)filepath;
+- (id)initWithStoreConfig:(SCStoreConfig *)cfg;
 - (RACSignal *)query:(SCQueryFilter *)filter;
 - (RACSignal *)create:(SCSpatialFeature *)feature;
 - (RACSignal *) delete:(SCSpatialFeature *)feature;

--- a/SpatialConnect/GeoJSONAdapter.m
+++ b/SpatialConnect/GeoJSONAdapter.m
@@ -41,9 +41,15 @@
   return self;
 }
 
-- (void)connect {
-  self.connector =
+- (Boolean)connect {
+  NSFileManager *fileManager = [NSFileManager defaultManager];
+  if ([fileManager fileExistsAtPath:geojsonFilePath]) {
+    self.connector =
       [[GeoJSONStorageConnector alloc] initWithFileName:geojsonFilePath];
+    return YES;
+  } else {
+    return NO;
+  }
 }
 
 - (void)supportedQueries {

--- a/SpatialConnect/GeoJSONAdapter.m
+++ b/SpatialConnect/GeoJSONAdapter.m
@@ -101,15 +101,13 @@
     }];
   } else {
     NSString *filePath = nil;
+    NSString *bundlePath = [SCFileUtils filePathFromMainBundle:self.uri];
+    NSString *documentsPath = [SCFileUtils filePathFromDocumentsDirectory:self.uri];
     if (geojsonFilePath) {
       filePath = geojsonFilePath;
-    }
-    NSString *bundlePath = [SCFileUtils filePathFromMainBundle:self.uri];
-    if ([[NSFileManager defaultManager] fileExistsAtPath:bundlePath]) {
+    } else if ([[NSFileManager defaultManager] fileExistsAtPath:bundlePath]) {
       filePath = bundlePath;
-    }
-    NSString *documentsPath = [SCFileUtils filePathFromDocumentsDirectory:self.uri];
-    if ([[NSFileManager defaultManager] fileExistsAtPath:documentsPath]) {
+    } else if ([[NSFileManager defaultManager] fileExistsAtPath:documentsPath]) {
       filePath = documentsPath;
     }
     return

--- a/SpatialConnect/GeoJSONStore.h
+++ b/SpatialConnect/GeoJSONStore.h
@@ -25,6 +25,12 @@
 extern const NSString *kTYPE;
 extern const int *kVERSON;
 extern const NSString *kSTORE_NAME;
+extern NSString *const SCGeoJsonErrorDomain;
+
+typedef NS_ENUM(NSInteger, SCGeoJsonError) {
+  SC_GEOJSON_FILENOTFOUND = 1,
+  SC_GEOJSON_ERRORDOWNLOADING = 2
+};
 
 @interface GeoJSONStore : SCDataStore <SCSpatialStore, SCDataStoreLifeCycle> {
   GeoJSONAdapter *adapter;

--- a/SpatialConnect/GeoJSONStore.m
+++ b/SpatialConnect/GeoJSONStore.m
@@ -57,14 +57,10 @@ const NSString *kSTORE_NAME = @"GeoJSONStore";
 
 - (void)initializeAdapter:(SCStoreConfig *)config {
   NSString *filePath;
-  if (config.isMainBundle) {
-    filePath = [SCFileUtils filePathFromMainBundle:config.uri];
+  if (isUnitTesting) {
+    filePath = [SCFileUtils filePathFromNSHomeDirectory:config.uri];
   } else {
-    if (isUnitTesting) {
-      filePath = [SCFileUtils filePathFromNSHomeDirectory:config.uri];
-    } else {
-      filePath = [SCFileUtils filePathFromDocumentsDirectory:config.uri];
-    }
+    filePath = [SCFileUtils filePathFromMainBundle:config.uri];
   }
   adapter = [[GeoJSONAdapter alloc] initWithFilePath:filePath];
   adapter.defaultStyle = self.style;
@@ -106,9 +102,13 @@ const NSString *kSTORE_NAME = @"GeoJSONStore";
 
 - (RACSignal *)start {
   self.status = SC_DATASTORE_STARTED;
-  [adapter connect];
+  Boolean running = [adapter connect];
+  if (running) {
+    self.status = SC_DATASTORE_RUNNING;
+  } else {
+    self.status = SC_DATASTORE_STOPPED;
+  }
   adapter.defaultStyle = self.style;
-  self.status = SC_DATASTORE_RUNNING;
   return [RACSignal empty];
 }
 

--- a/SpatialConnectTests/SCGeoJSONStoreTest.m
+++ b/SpatialConnectTests/SCGeoJSONStoreTest.m
@@ -1,0 +1,9 @@
+//
+//  SCGeoJSONStoreTest.m
+//  SpatialConnect
+//
+//  Created by Frank Rowe on 8/25/16.
+//  Copyright © 2016 Boundless Spatial. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>

--- a/SpatialConnectTests/SCGeoJSONStoreTest.m
+++ b/SpatialConnectTests/SCGeoJSONStoreTest.m
@@ -1,9 +1,61 @@
-//
-//  SCGeoJSONStoreTest.m
-//  SpatialConnect
-//
-//  Created by Frank Rowe on 8/25/16.
-//  Copyright © 2016 Boundless Spatial. All rights reserved.
-//
+/**
+ * Copyright 2016 Boundless http://boundlessgeo.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
 
-#import <Foundation/Foundation.h>
+#import "SpatialConnectHelper.h"
+#import <XCTest/XCTest.h>
+
+@interface SCGeoJSONStoreTest : XCTestCase
+@property SCNetworkService *net;
+@property SpatialConnect *sc;
+@end
+
+@implementation SCGeoJSONStoreTest
+
+@synthesize net, sc;
+
+- (void)setUp {
+  [super setUp];
+  self.sc = [SpatialConnectHelper loadConfig];
+  [self.sc startAllServices];
+}
+
+- (void)tearDown {
+  [super tearDown];
+  [self.sc stopAllServices];
+}
+
+//download geojson file and check if file exists
+- (void)testGeoJSONDownload {
+  XCTestExpectation *expect = [self expectationWithDescription:@"Delete"];
+  NSString *storeId = @"a5d93796-5026-46f7-a2ff-e5dec85d116c";
+  NSString *fileName = [NSString stringWithFormat:@"%@.geojson", storeId];
+  NSString *path = [SCFileUtils filePathFromNSHomeDirectory:fileName];
+  [[[sc.dataService storeStarted:storeId] map:^SCDataStore*(SCStoreStatusEvent *evt) {
+    SCDataStore *ds = [sc.dataService storeByIdentifier:storeId];
+    return ds;
+  }] subscribeNext:^(id<SCSpatialStore> ds) {
+    BOOL b = [[NSFileManager defaultManager] fileExistsAtPath:path];
+    XCTAssertTrue(b);
+    [expect fulfill];
+  } error:^(NSError *error) {
+    XCTFail(@"Error getting store");
+    [expect fulfill];
+  }];
+  [self waitForExpectationsWithTimeout:1000.0 handler:nil];
+}
+
+
+@end

--- a/SpatialConnectTests/tests.scfg
+++ b/SpatialConnectTests/tests.scfg
@@ -15,6 +15,13 @@
 "id":"a5d93796-5026-46f7-a2ff-e5dec85d116b"
 },
 {
+"store_type":"geojson",
+"version":"1",
+"name":"bars",
+"uri":"https://s3.amazonaws.com/test.spacon/bars.geojson",
+"id":"a5d93796-5026-46f7-a2ff-e5dec85d116c"
+},
+{
 "store_type":"gpkg",
 "version":"1",
 "name":"Haiti",


### PR DESCRIPTION
## Status

**READY**
## JIRA Ticket

SPACON-267
## Description
- Removes the `isMainBundle` option from the config for GeoJSON stores, and always loads files from the main bundle.
- Catches errors when trying to start a store when the file does not exist
## Todos
- [x] Tests
- [x] Documentation
- [x] License
## Steps to Test or Reproduce

``` sh
git fetch --all
git checkout <feature_branch> 
xctool -workspace SpatialConnect.xcworkspace -scheme SpatialConnect -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6 Plus' ONLY_ACTIVE_ARCH=NO test
```

@boundlessgeo/spatial-connect
