### PR TITLE
Query stores: return array of features on complete

### DIFF
--- a/SpatialConnect/SCDataService.h
+++ b/SpatialConnect/SCDataService.h
@@ -66,5 +66,7 @@
 - (RACSignal *)queryAllStores:(SCQueryFilter *)filter;
 - (RACSignal *)queryStoreById:(NSString *)storeId
                    withFilter:(SCQueryFilter *)filter;
+- (RACSignal *)queryStoresByIds:(NSArray *)storeIds
+                   withFilter:(SCQueryFilter *)filter;
 
 @end

--- a/SpatialConnect/SCDataService.m
+++ b/SpatialConnect/SCDataService.m
@@ -343,39 +343,9 @@ static NSString *const kSERVICENAME = @"SC_DATA_SERVICE";
 }
 
 - (RACSignal *)queryStores:(NSArray *)stores filter:(SCQueryFilter *)filter {
-  return
-      [RACSignal createSignal:^RACDisposable *(id<RACSubscriber> subscriber) {
-        __block NSUInteger queryCompleted = 0;
-        __block NSUInteger count = stores.count;
-        if (count == 0) {
-          [subscriber sendCompleted];
-        }
-        [[[[stores rac_sequence] signal]
-            flattenMap:^RACStream *(id<SCSpatialStore> store) {
-              return [RACSignal
-                  createSignal:^RACDisposable *(id<RACSubscriber> qSub) {
-                    [[store query:filter] subscribeNext:^(SCSpatialFeature *x) {
-                      [qSub sendNext:x];
-                    }
-                        error:^(NSError *error) {
-                          [qSub sendError:error];
-                        }
-                        completed:^{
-                          queryCompleted++;
-                          if (queryCompleted == count) {
-                            [subscriber sendCompleted];
-                          }
-                        }];
-                    return nil;
-                  }];
-            }] subscribeNext:^(SCSpatialFeature *x) {
-          [subscriber sendNext:x];
-        }
-            error:^(NSError *error) {
-              [subscriber sendError:error];
-            }];
-        return nil;
-      }];
+    return [[[stores rac_sequence] signal] flattenMap:^RACStream *(id<SCSpatialStore> store) {
+      return [store query:filter];
+    }];
 }
 
 - (RACSignal *)queryStoresByIds:(NSArray *)storeIds

--- a/SpatialConnect/SCDataService.m
+++ b/SpatialConnect/SCDataService.m
@@ -378,6 +378,24 @@ static NSString *const kSERVICENAME = @"SC_DATA_SERVICE";
       }];
 }
 
+- (RACSignal *)queryStoresByIds:(NSArray *)storeIds
+                   withFilter:(SCQueryFilter *)filter {
+  NSMutableArray *arr = [NSMutableArray new];
+  for (id obj in storeIds) {
+    NSString *storeId = obj;
+    id<SCSpatialStore> s = (id<SCSpatialStore>)[self.stores objectForKey:storeId];
+    SCDataStore *ds = (SCDataStore *)s;
+    BOOL conforms = [ds conformsToProtocol:@protocol(SCSpatialStore)];
+    SCDataStoreStatus d = ds.status;
+    BOOL running = d == SC_DATASTORE_RUNNING;
+    if (conforms && running) {
+      [arr addObject:ds];
+    }
+  };
+
+  return [self queryStores:arr filter:filter];
+}
+
 - (RACSignal *)queryStoreById:(NSString *)storeId
                    withFilter:(SCQueryFilter *)filter {
   id<SCSpatialStore> store =

--- a/SpatialConnect/SCJavascriptBridgeAPI.h
+++ b/SpatialConnect/SCJavascriptBridgeAPI.h
@@ -28,11 +28,11 @@
      responseSubscriber:(id<RACSubscriber>)subscriber;
 - (void)queryAllStores:(NSDictionary *)value
     responseSubscriber:(id<RACSubscriber>)subscriber;
-- (void)queryStoreById:(NSDictionary *)value
+- (void)queryStoresByIds:(NSDictionary *)value
     responseSubscriber:(id<RACSubscriber>)subscriber;
 - (void)queryAllGeoStores:(NSDictionary *)value
        responseSubscriber:(id<RACSubscriber>)subscriber;
-- (void)queryGeoStoreById:(NSDictionary *)value
+- (void)queryGeoStoresByIds:(NSDictionary *)value
        responseSubscriber:(id<RACSubscriber>)subscriber;
 - (void)createFeature:(NSDictionary *)value
    responseSubscriber:(id<RACSubscriber>)subscriber;

--- a/SpatialConnect/SCJavascriptBridgeAPI.m
+++ b/SpatialConnect/SCJavascriptBridgeAPI.m
@@ -138,16 +138,14 @@
 - (void)queryAllStores:(NSDictionary *)value
     responseSubscriber:(id<RACSubscriber>)subscriber {
   SCQueryFilter *filter = [SCQueryFilter filterFromDictionary:value[@"filter"]];
-  NSMutableArray *arr = [[NSMutableArray alloc] init];
   [[[[[SpatialConnect sharedInstance] dataService]
       queryAllStoresOfProtocol:@protocol(SCSpatialStore)
                         filter:filter]
       map:^NSDictionary *(SCSpatialFeature *value) {
         return [value JSONDict];
       }] subscribeNext:^(NSDictionary *d) {
-        [arr addObject:d];
+        [subscriber sendNext: d];
       } completed:^{
-        [subscriber sendNext:arr];
         [subscriber sendCompleted];
       }];
 }
@@ -155,13 +153,11 @@
 - (void)queryStoresByIds:(NSDictionary *)value
         responseSubscriber:(id<RACSubscriber>)subscriber {
   SCQueryFilter *filter = [SCQueryFilter filterFromDictionary:value[@"filter"]];
-  NSMutableArray *arr = [[NSMutableArray alloc] init];
   [[[[SpatialConnect sharedInstance] dataService]
     queryStoresByIds:value[@"storeId"]
-    withFilter:filter] subscribeNext:^(SCGeometry *g) {
-    [arr addObject:[g JSONDict]];
+    withFilter:filter] subscribeNext:^(SCSpatialFeature *value) {
+    [subscriber sendNext:[value JSONDict]];
   } completed:^{
-    [subscriber sendNext:arr];
     [subscriber sendCompleted];
   }];
 }
@@ -169,14 +165,12 @@
 - (void)queryAllGeoStores:(NSDictionary *)value
        responseSubscriber:(id<RACSubscriber>)subscriber {
   SCQueryFilter *filter = [SCQueryFilter filterFromDictionary:value[@"filter"]];
-  NSMutableArray *arr = [[NSMutableArray alloc] init];
   [[[[[SpatialConnect sharedInstance] dataService] queryAllStores:filter]
       map:^NSDictionary *(SCSpatialFeature *value) {
         return [value JSONDict];
       }] subscribeNext:^(NSDictionary *d) {
-        [arr addObject:d];
+        [subscriber sendNext:d];
       } completed:^{
-        [subscriber sendNext:arr];
         [subscriber sendCompleted];
    }];
 }
@@ -184,13 +178,13 @@
 - (void)queryGeoStoresByIds:(NSDictionary *)value
        responseSubscriber:(id<RACSubscriber>)subscriber {
   SCQueryFilter *filter = [SCQueryFilter filterFromDictionary:value[@"filter"]];
-  NSMutableArray *arr = [[NSMutableArray alloc] init];
-  [[[[SpatialConnect sharedInstance] dataService]
+  [[[[[SpatialConnect sharedInstance] dataService]
     queryStoresByIds:value[@"storeId"]
-    withFilter:filter] subscribeNext:^(SCGeometry *g) {
-    [arr addObject:[g JSONDict]];
+    withFilter:filter] map:^NSDictionary *(SCSpatialFeature *value) {
+    return [value JSONDict];
+  }] subscribeNext:^(NSDictionary *d) {
+    [subscriber sendNext:d];
   } completed:^{
-    [subscriber sendNext:arr];
     [subscriber sendCompleted];
   }];
 }
@@ -331,7 +325,6 @@
   NSString *s = [as xAccessToken];
   if (s) {
     [subscriber sendNext:s];
-    [subscriber sendCompleted];
   }
   [subscriber sendCompleted];
 }

--- a/SpatialConnect/SCJavascriptBridgeAPI.m
+++ b/SpatialConnect/SCJavascriptBridgeAPI.m
@@ -60,11 +60,17 @@
     case DATASERVICE_SPATIALQUERY:
       [self queryStoreById:action[@"payload"] responseSubscriber:subscriber];
       break;
+    case DATASERVICE_SPATIALQUERYBYIDS:
+      [self queryStoresByIds:action[@"payload"] responseSubscriber:subscriber];
+      break;
     case DATASERVICE_SPATIALQUERYALL:
       [self queryAllStores:action[@"payload"] responseSubscriber:subscriber];
       break;
     case DATASERVICE_GEOSPATIALQUERY:
       [self queryGeoStoreById:action[@"payload"] responseSubscriber:subscriber];
+      break;
+    case DATASERVICE_GEOSPATIALQUERYBYIDS:
+      [self queryGeoStoreByIds:action[@"payload"] responseSubscriber:subscriber];
       break;
     case DATASERVICE_GEOSPATIALQUERYALL:
       [self queryAllGeoStores:action[@"payload"] responseSubscriber:subscriber];
@@ -152,6 +158,20 @@
       }];
 }
 
+- (void)queryStoresByIds:(NSDictionary *)value
+        responseSubscriber:(id<RACSubscriber>)subscriber {
+  SCQueryFilter *filter = [SCQueryFilter filterFromDictionary:value[@"filter"]];
+  NSMutableArray *arr = [[NSMutableArray alloc] init];
+  [[[[SpatialConnect sharedInstance] dataService]
+    queryStoresByIds:value[@"storeId"]
+    withFilter:filter] subscribeNext:^(SCGeometry *g) {
+    [arr addObject:[g JSONDict]];
+  } completed:^{
+    [subscriber sendNext:arr];
+    [subscriber sendCompleted];
+  }];
+}
+
 - (void)queryStoreById:(NSDictionary *)value
     responseSubscriber:(id<RACSubscriber>)subscriber {
   NSMutableArray *arr = [[NSMutableArray alloc] init];
@@ -178,6 +198,20 @@
         [subscriber sendNext:arr];
         [subscriber sendCompleted];
    }];
+}
+
+- (void)queryGeoStoresByIds:(NSDictionary *)value
+       responseSubscriber:(id<RACSubscriber>)subscriber {
+  SCQueryFilter *filter = [SCQueryFilter filterFromDictionary:value[@"filter"]];
+  NSMutableArray *arr = [[NSMutableArray alloc] init];
+  [[[[SpatialConnect sharedInstance] dataService]
+    queryStoresByIds:value[@"storeId"]
+    withFilter:filter] subscribeNext:^(SCGeometry *g) {
+    [arr addObject:[g JSONDict]];
+  } completed:^{
+    [subscriber sendNext:arr];
+    [subscriber sendCompleted];
+  }];
 }
 
 - (void)queryGeoStoreById:(NSDictionary *)value

--- a/SpatialConnect/SCJavascriptBridgeAPI.m
+++ b/SpatialConnect/SCJavascriptBridgeAPI.m
@@ -138,22 +138,29 @@
 - (void)queryAllStores:(NSDictionary *)value
     responseSubscriber:(id<RACSubscriber>)subscriber {
   SCQueryFilter *filter = [SCQueryFilter filterFromDictionary:value[@"filter"]];
+  NSMutableArray *arr = [[NSMutableArray alloc] init];
   [[[[[SpatialConnect sharedInstance] dataService]
       queryAllStoresOfProtocol:@protocol(SCSpatialStore)
                         filter:filter]
       map:^NSDictionary *(SCSpatialFeature *value) {
         return [value JSONDict];
       }] subscribeNext:^(NSDictionary *d) {
-    [subscriber sendNext:d];
-  }];
+        [arr addObject:d];
+      } completed:^{
+        [subscriber sendNext:arr];
+        [subscriber sendCompleted];
+      }];
 }
 
 - (void)queryStoreById:(NSDictionary *)value
     responseSubscriber:(id<RACSubscriber>)subscriber {
+  NSMutableArray *arr = [[NSMutableArray alloc] init];
   [[[[SpatialConnect sharedInstance] dataService]
-      queryStoreById:[value[@"storeId"] stringValue]
+      queryStoreById:value[@"storeId"]
           withFilter:nil] subscribeNext:^(SCGeometry *g) {
-    [subscriber sendNext:[g JSONDict]];
+      [arr addObject:[g JSONDict]];
+  } completed:^{
+    [subscriber sendNext:arr];
     [subscriber sendCompleted];
   }];
 }
@@ -161,21 +168,28 @@
 - (void)queryAllGeoStores:(NSDictionary *)value
        responseSubscriber:(id<RACSubscriber>)subscriber {
   SCQueryFilter *filter = [SCQueryFilter filterFromDictionary:value[@"filter"]];
+  NSMutableArray *arr = [[NSMutableArray alloc] init];
   [[[[[SpatialConnect sharedInstance] dataService] queryAllStores:filter]
       map:^NSDictionary *(SCSpatialFeature *value) {
         return [value JSONDict];
       }] subscribeNext:^(NSDictionary *d) {
-    [subscriber sendNext:d];
-  }];
+        [arr addObject:d];
+      } completed:^{
+        [subscriber sendNext:arr];
+        [subscriber sendCompleted];
+   }];
 }
 
 - (void)queryGeoStoreById:(NSDictionary *)value
        responseSubscriber:(id<RACSubscriber>)subscriber {
   SCQueryFilter *filter = [SCQueryFilter filterFromDictionary:value[@"filter"]];
+  NSMutableArray *arr = [[NSMutableArray alloc] init];
   [[[[SpatialConnect sharedInstance] dataService]
-      queryStoreById:[value[@"storeId"] stringValue]
+      queryStoreById:value[@"storeId"]
           withFilter:filter] subscribeNext:^(SCGeometry *g) {
-    [subscriber sendNext:[g JSONDict]];
+    [arr addObject:[g JSONDict]];
+  } completed:^{
+    [subscriber sendNext:arr];
     [subscriber sendCompleted];
   }];
 }

--- a/SpatialConnect/SCJavascriptBridgeAPI.m
+++ b/SpatialConnect/SCJavascriptBridgeAPI.m
@@ -58,19 +58,13 @@
       [self activeStoreById:action[@"payload"] responseSubscriber:subscriber];
       break;
     case DATASERVICE_SPATIALQUERY:
-      [self queryStoreById:action[@"payload"] responseSubscriber:subscriber];
-      break;
-    case DATASERVICE_SPATIALQUERYBYIDS:
       [self queryStoresByIds:action[@"payload"] responseSubscriber:subscriber];
       break;
     case DATASERVICE_SPATIALQUERYALL:
       [self queryAllStores:action[@"payload"] responseSubscriber:subscriber];
       break;
     case DATASERVICE_GEOSPATIALQUERY:
-      [self queryGeoStoreById:action[@"payload"] responseSubscriber:subscriber];
-      break;
-    case DATASERVICE_GEOSPATIALQUERYBYIDS:
-      [self queryGeoStoreByIds:action[@"payload"] responseSubscriber:subscriber];
+      [self queryGeoStoresByIds:action[@"payload"] responseSubscriber:subscriber];
       break;
     case DATASERVICE_GEOSPATIALQUERYALL:
       [self queryAllGeoStores:action[@"payload"] responseSubscriber:subscriber];
@@ -172,19 +166,6 @@
   }];
 }
 
-- (void)queryStoreById:(NSDictionary *)value
-    responseSubscriber:(id<RACSubscriber>)subscriber {
-  NSMutableArray *arr = [[NSMutableArray alloc] init];
-  [[[[SpatialConnect sharedInstance] dataService]
-      queryStoreById:value[@"storeId"]
-          withFilter:nil] subscribeNext:^(SCGeometry *g) {
-      [arr addObject:[g JSONDict]];
-  } completed:^{
-    [subscriber sendNext:arr];
-    [subscriber sendCompleted];
-  }];
-}
-
 - (void)queryAllGeoStores:(NSDictionary *)value
        responseSubscriber:(id<RACSubscriber>)subscriber {
   SCQueryFilter *filter = [SCQueryFilter filterFromDictionary:value[@"filter"]];
@@ -207,20 +188,6 @@
   [[[[SpatialConnect sharedInstance] dataService]
     queryStoresByIds:value[@"storeId"]
     withFilter:filter] subscribeNext:^(SCGeometry *g) {
-    [arr addObject:[g JSONDict]];
-  } completed:^{
-    [subscriber sendNext:arr];
-    [subscriber sendCompleted];
-  }];
-}
-
-- (void)queryGeoStoreById:(NSDictionary *)value
-       responseSubscriber:(id<RACSubscriber>)subscriber {
-  SCQueryFilter *filter = [SCQueryFilter filterFromDictionary:value[@"filter"]];
-  NSMutableArray *arr = [[NSMutableArray alloc] init];
-  [[[[SpatialConnect sharedInstance] dataService]
-      queryStoreById:value[@"storeId"]
-          withFilter:filter] subscribeNext:^(SCGeometry *g) {
     [arr addObject:[g JSONDict]];
   } completed:^{
     [subscriber sendNext:arr];

--- a/SpatialConnect/SCJavascriptCommands.h
+++ b/SpatialConnect/SCJavascriptCommands.h
@@ -31,6 +31,12 @@ typedef NS_ENUM(NSInteger, SCJavascriptError) {
   SCJSERROR_SENSORSERVICE_GPS = 200
 };
 
+typedef NS_ENUM(NSInteger, SCBridgeStatus) {
+  SCJSSTATUS_NEXT = 0,
+  SCJSSTATUS_COMPLETED = 1,
+  SCJSSTATUS_ERROR = 2
+};
+
 #define SCJS_GEO_CONTAINS @"$geocontains"
 #define SCJS_GEO_DISJOINT @"$geodisjoint"
 #define SCJS_AND @"$and"

--- a/SpatialConnect/SCRCTBridge.h
+++ b/SpatialConnect/SCRCTBridge.h
@@ -20,11 +20,11 @@
 #import "SCJavascriptBridgeAPI.h"
 #import <Foundation/Foundation.h>
 
-@interface SCRCTBridge : NSObject
-
-@property(nonatomic) SCJavascriptBridgeAPI *bridge;
+@interface SCRCTBridge : NSObject {
+  SCJavascriptBridgeAPI *bridgeAPI;
+}
 
 - (void)handler:(NSDictionary *)data
-    responseCallback:(void (^)(NSDictionary *data))callback;
+    responseCallback:(void (^)(NSDictionary *data, NSInteger status))callback;
 
 @end

--- a/SpatialConnect/SCRCTBridge.m
+++ b/SpatialConnect/SCRCTBridge.m
@@ -17,31 +17,39 @@
  * under the License.
  ******************************************************************************/
 
+#import "Commands.h"
 #import "SCRCTBridge.h"
+#import "SCJavascriptCommands.h"
 #import "SCJavascriptBridgeAPI.h"
 
 @implementation SCRCTBridge
 
+
 - (id)init {
     if (self = [super init]) {
-        self.bridge = [[SCJavascriptBridgeAPI alloc] init];
+        bridgeAPI = [[SCJavascriptBridgeAPI alloc] init];
     }
     return self;
 }
     
-- (void) handler:(NSDictionary *)action responseCallback:(void(^)(NSDictionary *data))callback {
-    [[self.bridge parseJSAction:action] subscribeNext:^(NSDictionary *payload) {
+- (void) handler:(NSDictionary *)action responseCallback:(void(^)(NSDictionary *data, NSInteger status))callback {
+    [[bridgeAPI parseJSAction:action] subscribeNext:^(NSDictionary *payload) {
         NSDictionary *newAction = @{
             @"type": action[@"type"],
             @"payload": payload
         };
-        callback(newAction);
+        callback(newAction, SCJSSTATUS_NEXT);
+    } error:^(NSError *error) {
+        NSDictionary *newAction = @{
+            @"type": action[@"type"],
+            @"payload": [error localizedDescription]
+        };
+      callback(newAction, SCJSSTATUS_ERROR);
     } completed:^{
-      NSDictionary *completed = @{
-          @"type": action[@"type"],
-          @"payload": @"completed"
-      };
-      callback(completed);
+        NSDictionary *completed = @{
+            @"type": action[@"type"]
+        };
+        callback(completed, SCJSSTATUS_COMPLETED);
     }];
 }
 

--- a/SpatialConnect/SCRCTBridge.m
+++ b/SpatialConnect/SCRCTBridge.m
@@ -36,6 +36,12 @@
             @"payload": payload
         };
         callback(newAction);
+    } completed:^{
+      NSDictionary *completed = @{
+          @"type": action[@"type"],
+          @"payload": @"completed"
+      };
+      callback(completed);
     }];
 }
 

--- a/SpatialConnectTests/SCGeoJSONStoreTest.m
+++ b/SpatialConnectTests/SCGeoJSONStoreTest.m
@@ -44,20 +44,20 @@
   NSString *fileName = [NSString stringWithFormat:@"%@.geojson", storeId];
   NSString *path = [SCFileUtils filePathFromNSHomeDirectory:fileName];
   [[[[sc serviceStarted:[SCDataService serviceId]]
-      flattenMap:^RACStream *(id value) {
-        return [sc.dataService storeStarted:storeId];
-      }] map:^SCDataStore *(SCStoreStatusEvent *evt) {
-    SCDataStore *ds = [sc.dataService storeByIdentifier:storeId];
-    return ds;
-  }] subscribeNext:^(id<SCSpatialStore> ds) {
-    BOOL b = [[NSFileManager defaultManager] fileExistsAtPath:path];
-    XCTAssertTrue(b);
-    [expect fulfill];
-  }
-      error:^(NSError *error) {
-        XCTFail(@"Error getting store");
-        [expect fulfill];
-      }];
+     flattenMap:^RACStream *(id value) {
+       return [sc.dataService storeStarted:storeId];
+     }] map:^SCDataStore *(SCStoreStatusEvent *evt) {
+       SCDataStore *ds = [sc.dataService storeByIdentifier:storeId];
+       return ds;
+     }] subscribeNext:^(id<SCSpatialStore> ds) {
+       BOOL b = [[NSFileManager defaultManager] fileExistsAtPath:path];
+       XCTAssertTrue(b);
+       [expect fulfill];
+     }
+   error:^(NSError *error) {
+     XCTFail(@"Error getting store");
+     [expect fulfill];
+   }];
   [self waitForExpectationsWithTimeout:5.0 handler:nil];
 }
 

--- a/SpatialConnectTests/WFSDataStoreTest.m
+++ b/SpatialConnectTests/WFSDataStoreTest.m
@@ -80,8 +80,6 @@
         if (ds) {
           XCTAssertNotNil(ds.layerList, @"Layer list as array");
           SCQueryFilter *filter = [[SCQueryFilter alloc] init];
-          [filter
-              addLayerIds:[ds.layerList subarrayWithRange:NSMakeRange(0, 1)]];
           SCBoundingBox *bbox = [[SCBoundingBox alloc] initWithCoords:@[
             @(-124.07438528127528),
             @(42.922397667217076),
@@ -112,7 +110,7 @@
         }
       }];
   [sc startAllServices];
-  [self waitForExpectationsWithTimeout:15.0 handler:nil];
+  [self waitForExpectationsWithTimeout:5.0 handler:nil];
 }
 
 - (void)testWFSMultiLayerQuery {

--- a/SpatialConnectTests/tests.scfg
+++ b/SpatialConnectTests/tests.scfg
@@ -39,7 +39,7 @@
 "store_type":"wfs",
 "version":"1.1.0",
 "name":"WFS Demo",
-"default_layer":"osm:polygon_barrier",
+"default_layers":["osm:polygon_barrier"],
 "uri":"http://demo.boundlessgeo.com/geoserver/wfs",
 "id":"0f193979-b871-47cd-b60d-e271d6504359"
 }


### PR DESCRIPTION
## Status

**READY**
## JIRA Ticket

SPACON-208
## Description
- Make query stores return all features on complete, instead of return one feature at a time across the bridge. This gives large benefit to map performance.
- Adds `queryStoresByIds` method to bridge and Data Service
- Fixes WFS query test
- Requires Android parity
## Todos
- [x] Tests
- [x] Documentation
- [x] License
## Steps to Test or Reproduce

``` sh
git fetch --all
git checkout <feature_branch> 
xctool -workspace SpatialConnect.xcworkspace -scheme SpatialConnect -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6 Plus' ONLY_ACTIVE_ARCH=NO test
```

@boundlessgeo/spatial-connect
