### PR TITLE
Use SCHttpUtils in all store adapters

### DIFF
--- a/SpatialConnect/GeoJSONAdapter.m
+++ b/SpatialConnect/GeoJSONAdapter.m
@@ -20,6 +20,7 @@
 #import "GeoJSONAdapter.h"
 #import "GeoJSONStore.h"
 #import "SCFileUtils.h"
+#import "SCHttpUtils.h"
 #import "SCGeoJSON.h"
 #import "SCGeometry+GeoJSON.h"
 #import "SCGeometryCollection+GeoJSON.h"
@@ -87,7 +88,7 @@
     NSURL *url = [[NSURL alloc] initWithString:self.uri];
     return
     [RACSignal createSignal:^RACDisposable *(id<RACSubscriber> subscriber) {
-      [[self attemptFileDownload:url] subscribeNext:^(NSData *data) {
+      [[SCHttpUtils getRequestURLAsData:url] subscribeNext:^(NSData *data) {
         NSLog(@"Saving GEOJSON to %@", path);
         [data writeToFile:path atomically:YES];
         self.connector =
@@ -145,14 +146,6 @@
 
 - (NSArray *)layerList {
   return @[ @"default" ];
-}
-
-- (RACSignal *)attemptFileDownload:(NSURL *)fileUrl {
-  NSURLRequest *request = [[NSURLRequest alloc] initWithURL:fileUrl];
-  return [[NSURLConnection rac_sendAsynchronousRequest:request]
-          reduceEach:^id(NSURLResponse *response, NSData *data) {
-            return data;
-          }];
 }
 
 - (RACSignal *)query:(SCQueryFilter *)filter {

--- a/SpatialConnect/GeopackageFileAdapter.m
+++ b/SpatialConnect/GeopackageFileAdapter.m
@@ -18,6 +18,7 @@
  ******************************************************************************/
 #import "GeopackageFileAdapter.h"
 #import "GeopackageStore.h"
+#import "SCHttpUtils.h"
 #import "SCFileUtils.h"
 #import "SCGeometry+GPKG.h"
 #import "SCGeopackage.h"
@@ -26,7 +27,7 @@
 #import "SCPoint.h"
 
 @interface GeopackageFileAdapter ()
-- (RACSignal *)attemptFileDownload:(NSURL *)fileUrl;
+
 @end
 
 @interface GeopackageFileAdapter ()
@@ -96,7 +97,7 @@
     NSURL *url = [[NSURL alloc] initWithString:self.uri];
     return
         [RACSignal createSignal:^RACDisposable *(id<RACSubscriber> subscriber) {
-          [[self attemptFileDownload:url] subscribeNext:^(NSData *data) {
+          [[SCHttpUtils getRequestURLAsData:url] subscribeNext:^(NSData *data) {
             NSLog(@"Saving GPKG to %@", path);
             [data writeToFile:path atomically:YES];
             self.gpkg = [[SCGeopackage alloc] initWithFilename:path];
@@ -127,14 +128,6 @@
   if (self.gpkg) {
     [self.gpkg close];
   }
-}
-
-- (RACSignal *)attemptFileDownload:(NSURL *)fileUrl {
-  NSURLRequest *request = [[NSURLRequest alloc] initWithURL:fileUrl];
-  return [[NSURLConnection rac_sendAsynchronousRequest:request]
-      reduceEach:^id(NSURLResponse *response, NSData *data) {
-        return data;
-      }];
 }
 
 - (NSString *)defaultLayerName {


### PR DESCRIPTION
## Status

**READY**
## Description

Removes class methods for file downloading in place of common SCHttpUtils
## Todos
- [x] Tests
- [x] Documentation
- [x] License
## Steps to Test or Reproduce

``` sh
git fetch --all
git checkout <feature_branch> 
xctool -workspace SpatialConnect.xcworkspace -scheme SpatialConnect -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6 Plus' ONLY_ACTIVE_ARCH=NO test
```

@boundlessgeo/spatial-connect
