### PR TITLE
Authenticate on launch

### DIFF
--- a/SpatialConnect/SCAuthService.m
+++ b/SpatialConnect/SCAuthService.m
@@ -75,6 +75,16 @@ static NSString *const kSERVICENAME = @"SC_AUTH_SERVICE";
 
 - (RACSignal *)start {
   [super start];
+  [[[SpatialConnect sharedInstance] serviceStarted:[SCBackendService serviceId]]
+    subscribeNext:^(id value) {
+      NSString *password = [keychainItem objectForKey:(__bridge id)kSecValueData];
+      NSString *username = [keychainItem objectForKey:(__bridge id)kSecAttrAccount];
+      if (![password isEqualToString:@""] && ![username isEqualToString:@""]) {
+        [self authenticate:username password:password];
+      } else {
+        [loginStatus sendNext:@(SCAUTH_NOT_AUTHENTICATED)];
+      }
+    }];
   return [RACSignal empty];
 }
 

--- a/SpatialConnect/SpatialConnect.m
+++ b/SpatialConnect/SpatialConnect.m
@@ -144,12 +144,12 @@
 }
 
 - (void)startAllServices {
+  [self startService:[self.authService.class serviceId]];
   [self startService:[self.kvpService.class serviceId]];
   [self startService:[self.dataService.class serviceId]];
   [self startService:[self.configService.class serviceId]];
   [self startService:[self.sensorService.class serviceId]];
   [self startService:[self.rasterService.class serviceId]];
-  [self startService:[self.authService.class serviceId]];
 }
 
 - (void)stopAllServices {


### PR DESCRIPTION
## Status

**READY**
## Description
- Authenticate from keychain on AuthService start
- Wait for BackendService start
- Auth service must be started first
## Todos
- [x] Tests
- [x] Documentation
- [x] License
## Steps to Test or Reproduce

Outline the steps to test or reproduce the PR here.

``` sh
git fetch --all
git checkout <feature_branch> 
xctool -workspace SpatialConnect.xcworkspace -scheme SpatialConnect -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6 Plus' ONLY_ACTIVE_ARCH=NO test
```

@boundlessgeo/spatial-connect
