### PR TITLE
Allow FORM_STORE to be queried

### DIFF
--- a/SpatialConnect/SCFormStore.m
+++ b/SpatialConnect/SCFormStore.m
@@ -80,14 +80,6 @@
 
 #pragma mark -
 #pragma mark SCSpatialStore
-- (RACSignal *)query:(SCQueryFilter *)filter {
-  return
-      [RACSignal createSignal:^RACDisposable *(id<RACSubscriber> subscriber) {
-        [subscriber sendCompleted];
-        return nil;
-      }];
-}
-
 - (RACSignal *)queryById:(SCKeyTuple *)key {
   return
       [RACSignal createSignal:^RACDisposable *(id<RACSubscriber> subscriber) {


### PR DESCRIPTION
## Status

**READY**
## Description
- Removes the query method on FormStore that returns nil
- Query on FormStore now behaves like other Geopackage stores
## Todos
- [x] Tests
- [x] Documentation
- [x] License
## Steps to Test or Reproduce

``` sh
git fetch --all
git checkout <feature_branch> 
xctool -workspace SpatialConnect.xcworkspace -scheme SpatialConnect -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6 Plus' ONLY_ACTIVE_ARCH=NO test
```

@boundlessgeo/spatial-connect
