### PR TITLE
Remove form by key

### DIFF
--- a/SpatialConnect/SCBackendService.m
+++ b/SpatialConnect/SCBackendService.m
@@ -127,9 +127,7 @@ static NSString *const kSERVICENAME = @"SC_BACKEND_SERVICE";
     }
     case CONFIG_REMOVE_FORM: {
       [sc.dataService.formStore
-          unregisterFormByConfig:[[SCFormConfig alloc]
-                                     initWithDict:[payload
-                                                      objectFromJSONString]]];
+          unregisterFormByKey:payload];
       break;
     }
     default:

--- a/SpatialConnect/SCFormStore.h
+++ b/SpatialConnect/SCFormStore.h
@@ -30,6 +30,7 @@
 - (void)registerFormByConfig:(SCFormConfig *)f;
 - (void)updateFormByConfig:(SCFormConfig *)f;
 - (void)unregisterFormByConfig:(SCFormConfig *)f;
+- (void)unregisterFormByKey:(NSString *)k;
 - (NSArray *)formsDictionaryArray;
 
 @end

--- a/SpatialConnect/SCFormStore.m
+++ b/SpatialConnect/SCFormStore.m
@@ -83,6 +83,12 @@
   [_hasForms sendNext:@(storeForms.count > 0)];
 }
 
+- (void)unregisterFormByKey:(NSString *)key {
+  [storeForms removeObjectForKey:key];
+  [formIds removeObjectForKey:key];
+  [_hasForms sendNext:@(storeForms.count > 0)];
+}
+
 - (NSArray *)formsDictionaryArray {
   NSMutableArray *arr = [[NSMutableArray alloc] init];
   [storeForms


### PR DESCRIPTION
## Status

**READY**
## Description

Forms are deleted from just their `form_key`, not an entire form config
## Todos
- [ ] Tests
- [ ] Documentation
- [ ] License
## Steps to Test or Reproduce

Outline the steps to test or reproduce the PR here.

``` sh
git fetch --all
git checkout <feature_branch> 
xctool -workspace SpatialConnect.xcworkspace -scheme SpatialConnect -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6 Plus' ONLY_ACTIVE_ARCH=NO test
```

@boundlessgeo/spatial-connect
