### PR TITLE
Removing invalid form configs from being added to the form store

### DIFF
--- a/SpatialConnect/SCBackendService.m
+++ b/SpatialConnect/SCBackendService.m
@@ -120,7 +120,9 @@ static NSString *const kSERVICENAME = @"SC_BACKEND_SERVICE";
     case CONFIG_ADD_FORM: {
       SCFormConfig *f =
           [[SCFormConfig alloc] initWithDict:[payload objectFromJSONString]];
-      [sc.dataService.formStore registerFormByConfig:f];
+      if (f) {
+        [sc.dataService.formStore registerFormByConfig:f];
+      }
       break;
     }
     case CONFIG_UPDATE_FORM: {

--- a/SpatialConnect/SCConfig.m
+++ b/SpatialConnect/SCConfig.m
@@ -34,7 +34,10 @@
     NSArray *formDicts = d[@"forms"];
     [formDicts enumerateObjectsUsingBlock:^(NSDictionary *d, NSUInteger idx,
                                             BOOL *stop) {
-      [forms addObject:[[SCFormConfig alloc] initWithDict:d]];
+      SCFormConfig *f = [[SCFormConfig alloc] initWithDict:d];
+      if (f) {
+        [forms addObject:f];
+      }
     }];
     NSDictionary *rd = d[@"remote"];
     if (rd) {

--- a/SpatialConnect/SCFormConfig.m
+++ b/SpatialConnect/SCFormConfig.m
@@ -15,13 +15,17 @@
  */
 
 #import "SCFormConfig.h"
-#import "SCFormConfig.h"
+#import "JSONKit.h"
 
 static NSString *const IDENT = @"id";
 static NSString *const FORM_KEY = @"form_key";
 static NSString *const FORM_LABEL = @"form_label";
 static NSString *const VERSION = @"version";
 static NSString *const FIELDS = @"fields";
+
+@interface SCFormConfig()
+- (BOOL)isValid;
+@end
 
 @implementation SCFormConfig
 
@@ -35,8 +39,46 @@ static NSString *const FIELDS = @"fields";
     self.label = dict[FORM_LABEL];
     self.version = [dict[VERSION] integerValue];
     self.fields = dict[FIELDS];
+    if (![self isValid]) {
+      return nil;
+    }
   }
   return self;
+}
+
+- (BOOL)isValid {
+  __block BOOL isValid = YES;
+  if (self.identifier <= 0) {
+    NSLog(@"Identifier is invalid:%@",self.identifier);
+    isValid = NO;
+  }
+  if (!self.key || self.key.length <= 0) {
+    NSLog(@"form_key is an empty string");
+    isValid = NO;
+  }
+  if (!self.label || self.label.length <= 0) {
+    NSLog(@"form_label is an empty string");
+    isValid = NO;
+  }
+  if (!self.version || self.version <= 0) {
+    NSLog(@"");
+    isValid = NO;
+  }
+  [self.fields enumerateObjectsUsingBlock:^(NSDictionary *obj, NSUInteger idx, BOOL * stop) {
+      NSString *fieldKey = obj[@"field_key"];
+      NSString *fieldLabel = obj[@"field_label"];
+
+    if (!fieldKey || fieldKey.length == 0) {
+      NSLog(@"field_key is invalid for form:%@",key);
+      isValid = NO;
+    }
+
+    if(!fieldLabel || fieldLabel.length == 0) {
+      NSLog(@"field_label is invalid for form:%@",key);
+      isValid = NO;
+    }
+  }];
+  return isValid;
 }
 
 - (NSInteger)strToFormType:(NSString *)s {
@@ -149,6 +191,10 @@ static NSString *const FIELDS = @"fields";
   dict[FIELDS] = self.fields;
   dict[IDENT] = @(self.identifier);
   return [NSDictionary dictionaryWithDictionary:dict];
+}
+
+- (NSString *)description {
+  return self.JSONDict.JSONString;
 }
 
 @end

--- a/SpatialConnectTests/remote.scfg
+++ b/SpatialConnectTests/remote.scfg
@@ -1,10 +1,10 @@
 {
 "remote": {
 "http_protocol": "http",
-"http_host": "localhost",
+"http_host": "efc-dev.boundlessgeo.com",
 "http_port": 8085,
 "mqtt_protocol": "tcp",
-"mqtt_host": "localhost",
+"mqtt_host": "efc-dev.boundlessgeo.com",
 "mqtt_port": 1883
 }
 }


### PR DESCRIPTION
## Status

**READY**
## JIRA Ticket

SPACON-237
## Description

Removes invalid form schemas from being added to the config
## Todos
- [x] Tests
- [x] Documentation
- [x] License
## Steps to Test or Reproduce

Outline the steps to test or reproduce the PR here.

``` sh
git fetch --all
git checkout <feature_branch> 
xctool -workspace SpatialConnect.xcworkspace -scheme SpatialConnect -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6 Plus' ONLY_ACTIVE_ARCH=NO test
```

@boundlessgeo/spatial-connect
