### PR TITLE
Create local notifications

### DIFF
--- a/SpatialConnect/SCBackendService.h
+++ b/SpatialConnect/SCBackendService.h
@@ -14,6 +14,7 @@
  * limitations under the License
  */
 
+#import "SCNotification.h"
 #import "SCRemoteConfig.h"
 #import "SCService.h"
 #import "SCServiceLifecycle.h"
@@ -21,8 +22,10 @@
 #import <MQTTFramework/MQTTFramework.h>
 #import <MQTTFramework/MQTTSessionManager.h>
 #import <ReactiveCocoa/ReactiveCocoa.h>
+#import <UserNotifications/UserNotifications.h>
 
-@interface SCBackendService : SCService <SCServiceLifecycle> {
+@interface SCBackendService
+    : SCService <SCServiceLifecycle, UNUserNotificationCenterDelegate> {
   NSString *mqttEndpoint;
   NSString *mqttPort;
   NSString *mqttProtocol;
@@ -39,7 +42,8 @@
 @property(readonly, strong) RACBehaviorSubject *configReceived;
 
 - (id)initWithRemoteConfig:(SCRemoteConfig *)cfg;
-
+- (void)registerForLocalNotifications;
+- (void)createNotification:(SCNotification *)notification;
 - (void)publish:(SCMessage *)msg onTopic:(NSString *)topic;
 - (void)publishAtMostOnce:(SCMessage *)msg onTopic:(NSString *)topic;
 - (void)publishAtLeastOnce:(SCMessage *)msg onTopic:(NSString *)topic;

--- a/SpatialConnect/SCBackendService.h
+++ b/SpatialConnect/SCBackendService.h
@@ -42,8 +42,6 @@
 @property(readonly, strong) RACBehaviorSubject *configReceived;
 
 - (id)initWithRemoteConfig:(SCRemoteConfig *)cfg;
-- (void)registerForLocalNotifications;
-- (void)createNotification:(SCNotification *)notification;
 - (void)publish:(SCMessage *)msg onTopic:(NSString *)topic;
 - (void)publishAtMostOnce:(SCMessage *)msg onTopic:(NSString *)topic;
 - (void)publishAtLeastOnce:(SCMessage *)msg onTopic:(NSString *)topic;

--- a/SpatialConnect/SCBackendService.m
+++ b/SpatialConnect/SCBackendService.m
@@ -32,6 +32,8 @@ static NSString *const kSERVICENAME = @"SC_BACKEND_SERVICE";
 @property(nonatomic, readwrite, strong) RACSignal *notifications;
 - (void)subscribeToTopic:(NSString *)topic;
 - (void)connect;
+- (void)registerForLocalNotifications;
+- (void)createNotification:(SCNotification *)notification;
 - (NSString *)jwt;
 @end
 


### PR DESCRIPTION
## Status
**IN DEVELOPMENT**

## JIRA Ticket
SPACON-375

## Description
- Takes notifications off the queue and creates local iOS notifications
- Asks for permissions to display notifications on SCBackendService start
- Supports iOS 10 only

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] License

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

```sh
git fetch --all
git checkout <feature_branch> 
xctool -workspace SpatialConnect.xcworkspace -scheme SpatialConnect -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6 Plus' ONLY_ACTIVE_ARCH=NO test
```

@boundlessgeo/spatial-connect
