### PR TITLE
SCMessage payload should be valid json string

### DIFF
--- a/SpatialConnect/SCBackendService.m
+++ b/SpatialConnect/SCBackendService.m
@@ -99,9 +99,11 @@ static NSString *const kSERVICENAME = @"SC_BACKEND_SERVICE";
       break;
     }
     case CONFIG_REMOVE_STORE: {
+      NSDictionary *json = [payload objectFromJSONString];
+      NSString *storeid = [json objectForKey:@"id"];
       SCDataStore *ds = [[[SpatialConnect sharedInstance] dataService]
-          storeByIdentifier:payload];
-      [cachedConfig removeStore:payload];
+          storeByIdentifier:storeid];
+      [cachedConfig removeStore:storeid];
       [sc.dataService unregisterStore:ds];
       break;
     }
@@ -124,8 +126,10 @@ static NSString *const kSERVICENAME = @"SC_BACKEND_SERVICE";
       break;
     }
     case CONFIG_REMOVE_FORM: {
-      [cachedConfig removeForm:payload];
-      [sc.dataService.formStore unregisterFormByKey:payload];
+      NSDictionary *json = [payload objectFromJSONString];
+      NSString *formKey = [json objectForKey:@"form-key"];
+      [cachedConfig removeForm:formKey];
+      [sc.dataService.formStore unregisterFormByKey:formKey];
       break;
     }
     default:


### PR DESCRIPTION
## Status
**READY**

## JIRA Ticket
SPACON-403

## Description
- SCMessage payload should always be a valid json string
- Changed format for CONFIG_REMOVE_STORE from `payload: "<storeid>"` to `payload: "{id: "<storeid>"}"`
- Changed format for CONFIG_REMOVE_FORM from `payload: "<formkey>"` to `payload: "{form-key: "<formkey>"}"`

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] License

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

```sh
git fetch --all
git checkout <feature_branch> 
xctool -workspace SpatialConnect.xcworkspace -scheme SpatialConnect -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6 Plus' ONLY_ACTIVE_ARCH=NO test
```

@boundlessgeo/spatial-connect
