### PR TITLE
Fix form_key in CONFIG_REMOVE_FORM

### DIFF
--- a/SpatialConnect/SCBackendService.m
+++ b/SpatialConnect/SCBackendService.m
@@ -127,7 +127,7 @@ static NSString *const kSERVICENAME = @"SC_BACKEND_SERVICE";
     }
     case CONFIG_REMOVE_FORM: {
       NSDictionary *json = [payload objectFromJSONString];
-      NSString *formKey = [json objectForKey:@"form-key"];
+      NSString *formKey = [json objectForKey:@"form_key"];
       [cachedConfig removeForm:formKey];
       [sc.dataService.formStore unregisterFormByKey:formKey];
       break;
@@ -369,7 +369,7 @@ static NSString *const kSERVICENAME = @"SC_BACKEND_SERVICE";
 - (RACSignal *)publishReplyTo:(SCMessage *)msg onTopic:(NSString *)topic {
   SpatialConnect *sc = [SpatialConnect sharedInstance];
   NSTimeInterval ti = [[NSDate date] timeIntervalSince1970];
-  msg.correlationId = @(ti*1000).unsignedIntegerValue;
+  msg.correlationId = @(ti * 1000).unsignedIntegerValue;
   msg.replyTo =
       [NSString stringWithFormat:@"/device/%@-replyTo", sc.deviceIdentifier];
   msg.jwt = self.jwt;


### PR DESCRIPTION
## Status
**READY**

## Description
- Backend converts `form-key` to snakecase

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] License

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

```sh
git fetch --all
git checkout <feature_branch> 
xctool -workspace SpatialConnect.xcworkspace -scheme SpatialConnect -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6 Plus' ONLY_ACTIVE_ARCH=NO test
```

@boundlessgeo/spatial-connect
