### PR TITLE
Synchronous service start

### DIFF
--- a/SCServiceGraph.h
+++ b/SCServiceGraph.h
@@ -28,9 +28,9 @@
 - (SCServiceNode*)nodeById:(NSString*)serviceId;
 
 - (void)startAllServices;
-- (RACSignal *)startService:(NSString *)serviceId;
+- (BOOL)startService:(NSString *)serviceId;
 - (void)stopAllServices;
-- (RACSignal *)stopService:(NSString *)serviceId;
+- (BOOL)stopService:(NSString *)serviceId;
 - (void)restartAllServices;
 
 @end

--- a/SCServiceGraph.m
+++ b/SCServiceGraph.m
@@ -133,7 +133,14 @@
 }
 
 - (void)stopAllServices {
-//TODO
+  [serviceNodes enumerateObjectsUsingBlock:^(SCServiceNode *n, NSUInteger idx, BOOL * _Nonnull stop) {
+    BOOL stopped = [self stopService:[n.service.class serviceId]];
+    if (stopped) {
+      [self.serviceEventSubject sendNext:[SCServiceStatusEvent fromEvent:SC_SERVICE_EVT_STOPPED andServiceName:[n.service.class serviceId]]];
+    } else {
+      [self.serviceEventSubject sendNext:[SCServiceStatusEvent fromEvent:SC_SERVICE_EVT_ERROR andServiceName:[n.service.class serviceId]]];
+    }
+  }];
 }
 
 - (BOOL)stopService:(NSString *)serviceId {

--- a/SCServiceGraph.m
+++ b/SCServiceGraph.m
@@ -84,145 +84,85 @@
 }
 
 - (void)startAllServices {
-  [[serviceNodes.rac_sequence.signal flattenMap:^RACStream *(SCServiceNode *sn) {
-    return [self startService:[sn.service.class serviceId]];
-  }] subscribeError:^(NSError *error) {
-    DDLogError(@"StartAllServices Error:%@",error.description);
-  } completed:^{
-    DDLogInfo(@"StartAllServices Complete");
-    [self.serviceEventSubject sendNext:[SCServiceStatusEvent fromEvent:SC_SERVICE_EVT_ALLSTARTED andServiceName:nil]];
-  }];
-}
-
-- (RACSignal *)checkAndStartService:(id<SCServiceLifecycle>)service withDeps:(NSDictionary *)dict {
-  return [RACSignal createSignal:^RACDisposable *(id<RACSubscriber> subscriber) {
-    if ([service status] == SC_SERVICE_STARTED || [service status] == SC_SERVICE_RUNNING) {
-      [subscriber sendCompleted];
-      return nil;
+  [serviceNodes enumerateObjectsUsingBlock:^(SCServiceNode *n, NSUInteger idx, BOOL * _Nonnull stop) {
+    BOOL started = [self startService:[n.service.class serviceId]];
+    if (started) {
+      [self.serviceEventSubject sendNext:[SCServiceStatusEvent fromEvent:SC_SERVICE_EVT_RUNNING andServiceName:[n.service.class serviceId]]];
+    } else {
+      [self.serviceEventSubject sendNext:[SCServiceStatusEvent fromEvent:SC_SERVICE_EVT_ERROR andServiceName:[n.service.class serviceId]]];
     }
-    //We need to subscribe to the start to send events on the Service Event Subject
-    [[service start:dict] subscribeError:^(NSError *error) {
-      [self.serviceEventSubject sendNext:[SCServiceStatusEvent fromEvent:SC_SERVICE_EVT_ERROR andServiceName:[service.class serviceId]]];
-      [subscriber sendError:error];
-    } completed:^{
-      [self.serviceEventSubject sendNext:[SCServiceStatusEvent fromEvent:SC_SERVICE_EVT_RUNNING andServiceName:[service.class serviceId]]];
-      [subscriber sendCompleted];
-    }];
-    return nil;
   }];
 }
 
-- (RACSignal *)startService:(NSString *)serviceId {
-  SCServiceNode *node = [self nodeById:serviceId];
 
-  SCServiceStatus status = [node.service status];
-  // Terminal Case
-  if(status == SC_SERVICE_RUNNING) {
-    return [RACSignal empty];
+- (BOOL)startService:(NSString *)serviceId {
+  SCServiceNode *node = [self nodeById:serviceId];
+  if([node.service status] == SC_SERVICE_RUNNING) {
+    return YES;
   }
 
   // Get all the dependencies and recursively pass them into this method
-  RACSignal *dep$ = nil;
+  NSArray *depsStarts = nil;
   if (node.dependencies) {
-    dep$ = [node.dependencies.rac_sequence.signal flattenMap:^RACStream *(SCServiceNode *e) {
-      if ([e.service status] == SC_SERVICE_STARTED || [e.service status] == SC_SERVICE_RUNNING) {
-        return [RACSignal empty];
+    depsStarts = [[node.dependencies.rac_sequence filter:^BOOL(SCServiceNode *e) {
+      if ([e.service status] == SC_SERVICE_RUNNING) {
+        return YES;
       } else {
         return [self startService:[e.service.class serviceId]];
       }
-    }];
+    }] array];
   }
 
   //No Deps, just start it
-  if (!dep$) {
-    return [self checkAndStartService:node.service withDeps:nil];
+  if (!depsStarts) {
+    return [node.service start:nil];
   } else {
-    return [[[dep$ materialize] filter:^BOOL(RACEvent *evt) {
-      return evt.eventType == RACEventTypeError ||
-        evt.eventType == RACEventTypeCompleted;
-    }] flattenMap:^RACStream *(RACEvent *evt) {
-      if (evt.eventType == RACEventTypeError) {
-        return [RACSignal error:evt.error];
-      } else {
-        NSArray<NSString*>* keys = [[node.dependencies.rac_sequence map:^NSString*(SCServiceNode *n) {
-          return [((SCService*)n.service).class serviceId];
-        }] array];
-        NSArray *deps = [[node.dependencies.rac_sequence map:^id<SCServiceLifecycle>(SCServiceNode *n) {
-          return n.service;
-        }] array];
-        NSDictionary *dict = [NSDictionary dictionaryWithObjects:deps forKeys:keys];
-        return [self checkAndStartService:node.service withDeps:dict];
-      }
-    }];
+    if (node.dependencies.count != depsStarts.count) {
+      DDLogError(@"Not all of the dependencies started");
+      return NO;
+    }
+    NSArray<NSString*>* keys = [[node.dependencies.rac_sequence map:^NSString*(SCServiceNode *n) {
+      return [((SCService*)n.service).class serviceId];
+    }] array];
+    NSArray *deps = [[node.dependencies.rac_sequence map:^id<SCServiceLifecycle>(SCServiceNode *n) {
+      return n.service;
+    }] array];
+    NSDictionary *dict = [NSDictionary dictionaryWithObjects:deps forKeys:keys];
+    return [node.service start:dict];
   }
 }
 
 - (void)stopAllServices {
-  [[serviceNodes.rac_sequence.signal flattenMap:^RACStream *(SCServiceNode *sn) {
-    return [self stopService:[sn.service.class serviceId]];
-  }] subscribeError:^(NSError *error) {
-    DDLogError(@"StartAllServices Error:%@",error.description);
-  } completed:^{
-    DDLogInfo(@"StartAllServices Complete");
-  }];
+//TODO
 }
 
-- (RACSignal *)stopService:(NSString *)serviceId {
+- (BOOL)stopService:(NSString *)serviceId {
   SCServiceNode *node = [self nodeById:serviceId];
 
   if ([node.service status] == SC_SERVICE_STOPPED) {
-    return [RACSignal empty];
+    return YES;
   }
 
-  RACSignal *rec$ = nil;
+  NSArray *recipsStops = nil;
   if (node.recipients) {
-    rec$ = [node.recipients.rac_sequence.signal flattenMap:^RACStream *(SCServiceNode *e) {
+    recipsStops = [[node.recipients.rac_sequence filter:^BOOL(SCServiceNode *e) {
       if ([e.service status] == SC_SERVICE_STOPPED) {
-        return [RACSignal empty];
+        return YES;
       } else {
         return [self stopService:[e.service.class serviceId]];
       }
-    }];
+    }] array];
   }
 
-  //No Recips, just start it
-  if (!rec$) {
-    return [RACSignal createSignal:^RACDisposable *(id<RACSubscriber> subscriber) {
-      //We need to subscribe to the start to send events on the Service Event Subject
-      [[node.service stop] subscribeError:^(NSError *error) {
-        [self.serviceEventSubject sendNext:[SCServiceStatusEvent fromEvent:SC_SERVICE_EVT_ERROR andServiceName:[node.service.class serviceId]]];
-        [subscriber sendError:error];
-      } completed:^{
-        [self.serviceEventSubject sendNext:[SCServiceStatusEvent fromEvent:SC_SERVICE_EVT_STOPPED andServiceName:[node.service.class serviceId]]];
-        [subscriber sendCompleted];
-      }];
-      return nil;
-    }];
+  if (!recipsStops) {
+    return [node.service stop];
   } else {
-    return [[[rec$ materialize] filter:^BOOL(RACEvent *evt) {
-      return evt.eventType == RACEventTypeError ||
-      evt.eventType == RACEventTypeCompleted;
-    }] flattenMap:^RACStream *(RACEvent *evt) {
-      if (evt.eventType == RACEventTypeError) {
-        return [RACSignal error:evt.error];
-      } else {
-        return [RACSignal createSignal:^RACDisposable *(id<RACSubscriber> subscriber) {
-          //We need to subscribe to the start to send events on the Service Event Subject
-          if ([node.service status] == SC_SERVICE_STOPPED) {
-            [subscriber sendCompleted];
-            return nil;
-          }
-          [[node.service stop] subscribeError:^(NSError *error) {
-            [self.serviceEventSubject sendNext:[SCServiceStatusEvent fromEvent:SC_SERVICE_EVT_ERROR andServiceName:[node.service.class serviceId]]];
-            [subscriber sendError:error];
-          } completed:^{
-            [self.serviceEventSubject sendNext:[SCServiceStatusEvent fromEvent:SC_SERVICE_EVT_STOPPED andServiceName:[node.service.class serviceId]]];
-            [subscriber sendCompleted];
-          }];
-          return nil;
-        }];
-      }
-    }];
+    if (node.recipients.count != recipsStops.count) {
+      DDLogError(@"Not all of the dependencies started");
+      return NO;
+    } else {
+      return [node.service stop];
+    }
   }
 }
 

--- a/SCServiceGraph.m
+++ b/SCServiceGraph.m
@@ -173,4 +173,9 @@
   }
 }
 
+- (void)restartAllServices {
+  [self stopAllServices];
+  [self startAllServices];
+}
+
 @end

--- a/SpatialConnect/GeopackageStore.m
+++ b/SpatialConnect/GeopackageStore.m
@@ -205,10 +205,16 @@ NSString *const SCGeopackageErrorDomain = @"SCGeopackageErrorDomain";
     return [fs create:feature];
   } else {
     NSDictionary *userInfo = @{
-                               NSLocalizedDescriptionKey: NSLocalizedString(@"Operation was unsuccessful.", nil),
-                               NSLocalizedFailureReasonErrorKey: NSLocalizedString(@"Layer id does not exist.", nil),
-                               NSLocalizedRecoverySuggestionErrorKey: NSLocalizedString(@"Have you created a layer in Geopackage by this name?", nil)};
-                               return [RACSignal error:[NSError errorWithDomain:@"SpatialConnect" code:-1 userInfo:userInfo]];
+      NSLocalizedDescriptionKey :
+          NSLocalizedString(@"Operation was unsuccessful.", nil),
+      NSLocalizedFailureReasonErrorKey :
+          NSLocalizedString(@"Layer id does not exist.", nil),
+      NSLocalizedRecoverySuggestionErrorKey : NSLocalizedString(
+          @"Have you created a layer in Geopackage by this name?", nil)
+    };
+    return [RACSignal error:[NSError errorWithDomain:@"SpatialConnect"
+                                                code:-1
+                                            userInfo:userInfo]];
   }
 }
 

--- a/SpatialConnect/SCAuthService.m
+++ b/SpatialConnect/SCAuthService.m
@@ -68,27 +68,14 @@ static NSString *const kAuthServiceName = @"SC_AUTH_SERVICE";
 #pragma mark -
 #pragma SCServiceLifecycle
 
-- (RACSignal *)start:(NSDictionary<NSString *, id<SCServiceLifecycle>> *)deps {
-  self.status = SC_SERVICE_STARTED;
+- (BOOL)start:(NSDictionary<NSString *, id<SCServiceLifecycle>> *)deps {
   BOOL authed = [authProtocol authFromCache];
   if (authed) {
     [loginStatus sendNext:@(SCAUTH_AUTHENTICATED)];
   } else {
     [loginStatus sendNext:@(SCAUTH_NOT_AUTHENTICATED)];
   };
-  self.status = SC_SERVICE_RUNNING;
-  return [RACSignal empty];
-}
-
-- (void)pause {
-}
-
-- (void)resume {
-}
-
-- (RACSignal *)stop {
-  self.status = SC_SERVICE_STOPPED;
-  return [RACSignal empty];
+  return [super start:nil];
 }
 
 - (NSArray *)requires {

--- a/SpatialConnect/SCBackendService.h
+++ b/SpatialConnect/SCBackendService.h
@@ -14,15 +14,15 @@
  * limitations under the License
  */
 
+#import "SCAuthService.h"
 #import "SCConfigService.h"
 #import "SCDataService.h"
 #import "SCNotification.h"
 #import "SCRemoteConfig.h"
-#import "SCAuthService.h"
+#import "SCSensorService.h"
 #import "SCService.h"
 #import "SCServiceLifecycle.h"
 #import "Scmessage.pbobjc.h"
-#import "SCSensorService.h"
 #import <MQTTFramework/MQTTFramework.h>
 #import <MQTTFramework/MQTTSessionManager.h>
 #import <ReactiveCocoa/ReactiveCocoa.h>
@@ -39,9 +39,9 @@
   MQTTSessionManager *sessionManager;
   RACSignal *multicast;
   SCConfigService *configService;
-      SCAuthService *authService;
+  SCAuthService *authService;
   SCDataService *dataService;
-      SCSensorService *sensorService;
+  SCSensorService *sensorService;
 }
 
 /*!

--- a/SpatialConnect/SCBackendService.m
+++ b/SpatialConnect/SCBackendService.m
@@ -62,8 +62,7 @@ static NSString *const kBackendServiceName = @"SC_BACKEND_SERVICE";
   return self;
 }
 
-- (RACSignal *)start:(NSDictionary<NSString *, id<SCServiceLifecycle>> *)deps {
-  self.status = SC_SERVICE_STARTED;
+- (BOOL)start:(NSDictionary<NSString *, id<SCServiceLifecycle>> *)deps {
   authService = [deps objectForKey:[SCAuthService serviceId]];
   configService = [deps objectForKey:[SCConfigService serviceId]];
   sensorService = [deps objectForKey:[SCSensorService serviceId]];
@@ -72,16 +71,14 @@ static NSString *const kBackendServiceName = @"SC_BACKEND_SERVICE";
   [self listenForNetworkConnection];
   [self registerForLocalNotifications];
   DDLogInfo(@"Backend Service Started");
-  self.status = SC_SERVICE_RUNNING;
-  return [RACSignal empty];
+  return [super start:nil];
 }
 
-- (RACSignal *)stop {
-  self.status = SC_SERVICE_STOPPED;
+- (BOOL)stop {
   if (sessionManager) {
     [sessionManager disconnect];
   }
-  return [RACSignal empty];
+  return [super stop];
 }
 
 - (NSArray *)requires {

--- a/SpatialConnect/SCBackendService.m
+++ b/SpatialConnect/SCBackendService.m
@@ -82,7 +82,10 @@ static NSString *const kBackendServiceName = @"SC_BACKEND_SERVICE";
 }
 
 - (NSArray *)requires {
-  return @[ [SCAuthService serviceId], [SCConfigService serviceId], [SCSensorService serviceId], [SCDataService serviceId] ];
+  return @[
+    [SCAuthService serviceId], [SCConfigService serviceId],
+    [SCSensorService serviceId], [SCDataService serviceId]
+  ];
 }
 
 - (void)registerForLocalNotifications {
@@ -191,8 +194,7 @@ static NSString *const kBackendServiceName = @"SC_BACKEND_SERVICE";
   NSDictionary *regDict = @{
     @"identifier" : [[SpatialConnect sharedInstance] deviceIdentifier],
     @"device_info" : @{@"os" : @"ios"},
-    @"name" :
-        [NSString stringWithFormat:@"mobile:%@", [authService username]]
+    @"name" : [NSString stringWithFormat:@"mobile:%@", [authService username]]
   };
   SCMessage *regMsg = [[SCMessage alloc] init];
   regMsg.action = CONFIG_REGISTER_DEVICE;
@@ -310,11 +312,10 @@ static NSString *const kBackendServiceName = @"SC_BACKEND_SERVICE";
 - (void)authListener {
   // You have the url to the server. Wait for someone to properly
   // authenticate before fetching the config
-  RACSignal *authed =
-      [[[authService loginStatus] filter:^BOOL(NSNumber *n) {
-        SCAuthStatus s = [n integerValue];
-        return s == SCAUTH_AUTHENTICATED;
-      }] take:1];
+  RACSignal *authed = [[[authService loginStatus] filter:^BOOL(NSNumber *n) {
+    SCAuthStatus s = [n integerValue];
+    return s == SCAUTH_AUTHENTICATED;
+  }] take:1];
 
   RACSignal *failedAuth =
       [[[authService loginStatus] filter:^BOOL(NSNumber *n) {

--- a/SpatialConnect/SCConfigService.m
+++ b/SpatialConnect/SCConfigService.m
@@ -37,20 +37,15 @@ static NSString *const kSERVICENAME = @"SC_CONFIG_SERVICE";
   return self;
 }
 
-- (RACSignal *)start:(NSDictionary<NSString *, id<SCServiceLifecycle>> *)deps {
-  self.status = SC_SERVICE_STARTED;
+- (BOOL)start:(NSDictionary<NSString *, id<SCServiceLifecycle>> *)deps {
   dataService = [deps objectForKey:[SCDataService serviceId]];
-  DDLogInfo(@"Config Service Started");
   [self loadConfigs];
-  self.status = SC_SERVICE_RUNNING;
-  DDLogInfo(@"Config Service Running");
-  return [RACSignal empty];
+  return [super start:nil];
 }
 
-- (RACSignal *)stop {
-  self.status = SC_SERVICE_STOPPED;
+- (BOOL)stop {
   [self clearConfigs];
-  return [RACSignal empty];
+  return [super stop];
 }
 
 - (NSArray *)requires {

--- a/SpatialConnect/SCDataService.m
+++ b/SpatialConnect/SCDataService.m
@@ -272,34 +272,34 @@ static NSString *const kSERVICENAME = @"SC_DATA_SERVICE";
 
 #pragma mark -
 #pragma mark SCServiceLifecycle
-- (RACSignal *)start:(NSDictionary<NSString *, id<SCServiceLifecycle>> *)deps {
-  self.status = SC_SERVICE_STARTED;
-  DDLogInfo(@"Starting Data Service...");
+- (BOOL)start:(NSDictionary<NSString *, id<SCServiceLifecycle>> *)deps {
   _sensorService =
       (SCSensorService *)[deps objectForKey:[SCSensorService serviceId]];
   [self setupSubscriptions];
   [self startAllStores];
   self.status = SC_SERVICE_RUNNING;
   DDLogInfo(@"Data Service Running");
-  return [RACSignal empty];
+  return [super start:nil];
 }
 
-- (RACSignal *)stop {
+- (BOOL)stop {
   [self stopAllStores];
   self.stores = [NSMutableDictionary new];
   self.storesStarted = NO;
   [_hasStores sendNext:@(NO)];
-  return [RACSignal empty];
+  return [super stop];
 }
 
-- (void)pause {
+- (BOOL)pause {
   [self stopAllStores];
   self.storesStarted = NO;
+  return [super pause];
 }
 
-- (void)resume {
+- (BOOL)resume {
   [self startAllStores];
   [self setupSubscriptions];
+  return [super resume];
 }
 
 - (NSArray *)requires {

--- a/SpatialConnect/SCDataStore.m
+++ b/SpatialConnect/SCDataStore.m
@@ -97,7 +97,7 @@
         [[SCHttpUtils getRequestURLAsData:u] subscribeNext:^(RACTuple *t) {
           data = t.first;
           self.downloadProgress = t.second;
-        
+
         }
             error:^(NSError *error) {
               self.status = SC_DATASTORE_DOWNLOADFAIL;

--- a/SpatialConnect/SCHttpUtils.m
+++ b/SpatialConnect/SCHttpUtils.m
@@ -55,7 +55,7 @@
                                        returningResponse:&response
                                                    error:&error];
   if (error) {
-    DDLogError(@"%@",error);
+    DDLogError(@"%@", error);
     return nil;
   }
   return data;

--- a/SpatialConnect/SCSensorService.m
+++ b/SpatialConnect/SCSensorService.m
@@ -65,8 +65,7 @@ static NSString *const kSERVICENAME = @"SC_SENSOR_SERVICE";
 #pragma mark -
 #pragma mark SCServiceLifecyle methods
 
-- (RACSignal *)start:(NSDictionary<NSString *, id<SCServiceLifecycle>> *)deps {
-  self.status = SC_SERVICE_STARTED;
+- (BOOL)start:(NSDictionary<NSString *, id<SCServiceLifecycle>> *)deps {
   DDLogInfo(@"Starting Sensor Service...");
   if (!locationManager) {
     locationManager = [CLLocationManager new];
@@ -91,26 +90,26 @@ static NSString *const kSERVICENAME = @"SC_SENSOR_SERVICE";
 
   [self setupSignals];
   DDLogInfo(@"Sensor Service Started");
-  self.status = SC_SERVICE_RUNNING;
-  return [RACSignal empty];
+  return [super start:nil];
 }
 
-- (RACSignal *)stop {
+- (BOOL)stop {
   if (locationManager) {
     [self stopLocationManager];
     locationManager = nil;
     locationManager.delegate = nil;
   }
-  self.status = SC_SERVICE_STOPPED;
-  return [RACSignal empty];
+  return [super stop];
 }
 
-- (void)resume {
+- (BOOL)resume {
   [self shoudlEnableGPS];
+  return [super resume];
 }
 
-- (void)pause {
+- (BOOL)pause {
   [self stopLocationManager];
+  return [super pause];
 }
 
 - (NSArray *)requires {

--- a/SpatialConnect/SCService.h
+++ b/SpatialConnect/SCService.h
@@ -22,7 +22,7 @@
 
 @interface SCService : NSObject <SCServiceLifecycle>
 
-@property(atomic,readonly) SCServiceStatus status;
+@property(atomic, readonly) SCServiceStatus status;
 
 + (NSString *)serviceId;
 

--- a/SpatialConnect/SCService.h
+++ b/SpatialConnect/SCService.h
@@ -20,9 +20,9 @@
 #import "SCServiceLifecycle.h"
 #import "SCServiceStatusEvent.h"
 
-@interface SCService : NSObject
+@interface SCService : NSObject <SCServiceLifecycle>
 
-@property(atomic) SCServiceStatus status;
+@property(atomic,readonly) SCServiceStatus status;
 
 + (NSString *)serviceId;
 

--- a/SpatialConnect/SCService.m
+++ b/SpatialConnect/SCService.m
@@ -23,8 +23,8 @@
 
 @interface SCService ()
 
-@property(nonatomic, strong) NSString *identifier;
-
+@property(strong) NSString *identifier;
+@property(atomic,readwrite) SCServiceStatus status;
 @end
 
 @implementation SCService
@@ -44,6 +44,26 @@
 + (NSString *)serviceId {
   NSAssert(NO, @"Name must be set on the Service");
   return nil;
+}
+
+- (BOOL)start:(NSDictionary<NSString *,id<SCServiceLifecycle>> *)deps {
+  self.status = SC_SERVICE_RUNNING;
+  return YES;
+}
+
+- (BOOL)pause {
+  self.status = SC_SERVICE_PAUSED;
+  return YES;
+}
+
+- (BOOL)resume {
+  self.status = SC_SERVICE_RUNNING;
+  return YES;
+}
+
+- (BOOL)stop {
+  self.status = SC_SERVICE_STOPPED;
+  return YES;
 }
 
 @end

--- a/SpatialConnect/SCService.m
+++ b/SpatialConnect/SCService.m
@@ -24,7 +24,7 @@
 @interface SCService ()
 
 @property(strong) NSString *identifier;
-@property(atomic,readwrite) SCServiceStatus status;
+@property(atomic, readwrite) SCServiceStatus status;
 @end
 
 @implementation SCService
@@ -46,7 +46,7 @@
   return nil;
 }
 
-- (BOOL)start:(NSDictionary<NSString *,id<SCServiceLifecycle>> *)deps {
+- (BOOL)start:(NSDictionary<NSString *, id<SCServiceLifecycle>> *)deps {
   self.status = SC_SERVICE_RUNNING;
   return YES;
 }

--- a/SpatialConnect/SCServiceLifecycle.h
+++ b/SpatialConnect/SCServiceLifecycle.h
@@ -21,7 +21,6 @@
 #import <ReactiveCocoa/ReactiveCocoa.h>
 
 typedef NS_ENUM(NSInteger, SCServiceStatus) {
-  SC_SERVICE_STARTED,
   SC_SERVICE_PAUSED,
   SC_SERVICE_RUNNING,
   SC_SERVICE_STOPPED,
@@ -31,10 +30,10 @@ typedef NS_ENUM(NSInteger, SCServiceStatus) {
 @protocol SCServiceLifecycle <NSObject>
 
 @required
-- (RACSignal *)start:(NSDictionary<NSString *, id<SCServiceLifecycle>> *)deps;
-- (void)pause;
-- (void)resume;
-- (RACSignal *)stop;
+- (BOOL)start:(NSDictionary<NSString *, id<SCServiceLifecycle>> *)deps;
+- (BOOL)pause;
+- (BOOL)resume;
+- (BOOL)stop;
 - (void)startError:(NSError *)e;
 - (NSArray *)requires;
 - (SCServiceStatus)status;

--- a/SpatialConnect/SpatialConnect.m
+++ b/SpatialConnect/SpatialConnect.m
@@ -111,15 +111,7 @@
 }
 
 - (void)startService:(NSString *)serviceId {
-  [[_serviceGraph startService:serviceId] subscribeNext:^(id x) {
-    DDLogInfo(@"%@", serviceId);
-  }
-      error:^(NSError *error) {
-        DDLogError(@"%@", error.description);
-      }
-      completed:^{
-        DDLogInfo(@"%@", serviceId);
-      }];
+  [_serviceGraph startService:serviceId];
 }
 
 - (void)stopService:(NSString *)serviceId {

--- a/SpatialConnectTests/SCServiceTest.m
+++ b/SpatialConnectTests/SCServiceTest.m
@@ -91,4 +91,23 @@
   [self waitForExpectationsWithTimeout:10.0 handler:nil];
 }
 
+- (void)testServiceStop {
+  XCTestExpectation *expect =
+  [self expectationWithDescription:@"Config Service Start"];
+  [[self.sc serviceRunning:[SCConfigService serviceId]]
+   subscribeError:^(NSError *error) {
+     DDLogError(@"Error:%@", error.description);
+     [expect fulfill];
+   }
+   completed:^{
+     [self.sc stopAllServices];
+     XCTAssertNotNil(self.sc.configService);
+     XCTAssertTrue(self.sc.configService.status == SC_SERVICE_STOPPED);
+     XCTAssertTrue(self.sc.dataService.status == SC_SERVICE_STOPPED);
+     XCTAssertTrue(self.sc.sensorService.status == SC_SERVICE_STOPPED);
+     [expect fulfill];
+   }];
+  [self waitForExpectationsWithTimeout:10.0 handler:nil];
+}
+
 @end


### PR DESCRIPTION
## Status
**READY**

## JIRA Ticket
SPACON-565

## Description
Service start is now synchronous and `SC_SERVICE_STARTED` has been removed since there is no need to check status of store start (fail or successful start).

## Todos
- [x] Tests
- [x] Documentation
- [x] License

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

```sh
git fetch --all
git checkout <feature_branch> 
xctool -workspace SpatialConnect.xcworkspace -scheme SpatialConnect -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6 Plus' ONLY_ACTIVE_ARCH=NO test
```

@boundlessgeo/spatial-connect
