### PR TITLE
add GeoJSONDict method to SCSpatialFeature

### DIFF
--- a/SpatialConnect/GeopackageStore.m
+++ b/SpatialConnect/GeopackageStore.m
@@ -290,7 +290,7 @@ NSString *const SCGeopackageErrorDomain = @"SCGeopackageErrorDomain";
 }
 
 - (NSDictionary *)generateSendPayload:(SCSpatialFeature *)f {
-  return [f JSONDict];
+  return [f GeoJSONDict];
 }
 
 - (RACSignal *)updateAuditTable:(SCSpatialFeature *)feature {

--- a/SpatialConnect/SCFormStore.m
+++ b/SpatialConnect/SCFormStore.m
@@ -125,7 +125,7 @@
 
 - (NSDictionary *)generateSendPayload:(SCSpatialFeature *)f {
   NSNumber *formId = [formIds objectForKey:f.layerId];
-  NSDictionary *payload = @{ @"form_id" : formId, @"feature" : f.JSONDict };
+  NSDictionary *payload = @{ @"form_id" : formId, @"feature" : f.GeoJSONDict };
   return payload;
 }
 

--- a/SpatialConnect/SCSpatialFeature.h
+++ b/SpatialConnect/SCSpatialFeature.h
@@ -36,4 +36,5 @@
 
 - (SCKeyTuple *)key;
 - (NSDictionary *)JSONDict;
+- (NSDictionary *)GeoJSONDict;
 @end

--- a/SpatialConnect/SCSpatialFeature.m
+++ b/SpatialConnect/SCSpatialFeature.m
@@ -104,4 +104,11 @@
   return [NSDictionary dictionaryWithDictionary:dict];
 }
 
+// return valid geojson for an unlocated feature
+- (NSDictionary *)GeoJSONDict {
+  NSMutableDictionary *dict = [NSMutableDictionary dictionaryWithDictionary:[self JSONDict]];
+  dict[@"geometry"] = [NSNull null];
+  return [NSDictionary dictionaryWithDictionary:dict];
+}
+
 @end


### PR DESCRIPTION
## Status
**READY**

## Description
Form submissions must be valid geojson. If device gps is off, the form submission must have a null geometry.

- Adds the `GeoJSONDict` method to return valid geojson for an `SCSpatialFeature` object
