### PR TITLE
bugFix: DATASERVICE_QUERY not supported

### DIFF
--- a/SpatialConnect/SCJavascriptBridgeAPI.m
+++ b/SpatialConnect/SCJavascriptBridgeAPI.m
@@ -58,7 +58,7 @@
       [self activeStoreById:action[@"payload"] responseSubscriber:subscriber];
     else if ([actionType isEqualToString:DATASERVICE_STORELIST])
       [self storeList:subscriber];
-    else if ([actionType isEqualToString:DATASERVICE_QUERYALL])
+    else if ([actionType isEqualToString:DATASERVICE_QUERY])
       [self queryStoresByIds:action[@"payload"] responseSubscriber:subscriber];
     else if ([actionType isEqualToString:DATASERVICE_QUERYALL])
       [self queryAllStores:action[@"payload"] responseSubscriber:subscriber];


### PR DESCRIPTION
## Status
**READY**

## JIRA Ticket
none

## Description
i think this was just a copy paste error, i think those `QUERY` messages are meant to coincide with https://github.com/boundlessgeo/spatialconnect-ios-sdk/blob/278121a469c0ed2ddfc0aae47b19773e14634fc7/SpatialConnect/Vendor/spatialconnect-schema/Commands.h#L11-L14

## Todos
- [ ] Tests

@boundlessgeo/spatial-connect
