### PR TITLE
updating create feature payload to use layer_id instead of form_id

### DIFF
--- a/SpatialConnect/SCFormStore.m
+++ b/SpatialConnect/SCFormStore.m
@@ -125,7 +125,7 @@
 
 - (NSDictionary *)generateSendPayload:(SCSpatialFeature *)f {
   NSNumber *formId = [formIds objectForKey:f.layerId];
-  NSDictionary *payload = @{ @"form_id" : formId, @"feature" : f.GeoJSONDict };
+  NSDictionary *payload = @{ @"layer_id" : formId, @"feature" : f.GeoJSONDict };
   return payload;
 }
 


### PR DESCRIPTION
This matches the [api branch of the android sdk](https://github.com/boundlessgeo/spatialconnect-android-sdk/blob/api/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/stores/FormStore.java#L120)