### PR TITLE
Change formId to string and allow null formId in payload

### DIFF
--- a/SpatialConnect/SCBackendService.m
+++ b/SpatialConnect/SCBackendService.m
@@ -369,8 +369,13 @@ static NSString *const QUERY_TOPIC = @"query";
       SCDataStore *store = [dataService storeByIdentifier:[feature storeId]];
       id<SCSyncableStore> ss = (id<SCSyncableStore>)store;
       Msg *msg = [[Msg alloc] init];
-      msg.payload = [[ss generateSendPayload:feature] JSONString];
       msg.action = CREATE_FEATURE;
+      NSDictionary *payload = [ss generateSendPayload:feature];
+      if ([[payload allKeys] count] == 0) {
+        return [RACSignal empty];
+      } else {
+        msg.payload = [payload JSONString];
+      }
       return [[self publishReplyTo:msg onTopic:COMMAND_TOPIC] flattenMap:^RACSignal *(Msg *m) {
         NSString *json = m.payload;
         NSDictionary *dict = [json objectFromJSONString];

--- a/SpatialConnect/SCFormStore.m
+++ b/SpatialConnect/SCFormStore.m
@@ -125,8 +125,12 @@
 
 - (NSDictionary *)generateSendPayload:(SCSpatialFeature *)f {
   NSString *layerId = [formIds objectForKey:f.layerId];
-  NSDictionary *payload = @{ @"layer_id" : layerId == nil ? [NSNull null] : layerId, @"feature" : f.GeoJSONDict };
-  return payload;
+  if (layerId != nil) {
+    return @{ @"layer_id" : layerId, @"feature" : f.GeoJSONDict };
+  } else {
+    DDLogWarn(@"Did not send feature b/c layer id was null for layer key: %@", f.layerId);
+    return @{};
+  }
 }
 
 

--- a/SpatialConnect/SCFormStore.m
+++ b/SpatialConnect/SCFormStore.m
@@ -124,8 +124,8 @@
 }
 
 - (NSDictionary *)generateSendPayload:(SCSpatialFeature *)f {
-  NSNumber *formId = [formIds objectForKey:f.layerId];
-  NSDictionary *payload = @{ @"layer_id" : formId, @"feature" : f.GeoJSONDict };
+  NSString *layerId = [formIds objectForKey:f.layerId];
+  NSDictionary *payload = @{ @"layer_id" : layerId == nil ? [NSNull null] : layerId, @"feature" : f.GeoJSONDict };
   return payload;
 }
 


### PR DESCRIPTION
## Status
**READY**

## JIRA Ticket
The ticket id

## Description
The layerId can be `nil` if generateSendPayload is called before the entire config is received and parsed. We should either attach layerId directly to the spatialfeature (in addition to layer_key), or wait to sync stores until after config is received.
