### PR TITLE
Fix duplicate subscriptions

### DIFF
--- a/SpatialConnect/SCBackendService.m
+++ b/SpatialConnect/SCBackendService.m
@@ -271,9 +271,9 @@ static NSString *const kBackendServiceName = @"SC_BACKEND_SERVICE";
     multicast = [[d publish] autoconnect];
     sessionManager.delegate = (id<MQTTSessionManagerDelegate>)self;
 
-    [[connectedToBroker filter:^BOOL(NSNumber *v) {
+    [[[connectedToBroker filter:^BOOL(NSNumber *v) {
       return v.boolValue;
-    }] subscribeNext:^(id x) {
+    }] take:1] subscribeNext:^(id x) {
       [self setupSubscriptions];
       [self registerAndFetchConfig];
       [self listenForSyncEvents];


### PR DESCRIPTION
## Status
**READY**

## JIRA Ticket
MOB-107

## Description
This fixes a bug where mqtt would resubscribe to certain streams every time it reconnected. Now, it only sets up subscriptions on the initial connection.