### PR TITLE
[WIP] Ability to use sdk as data store only [WIP]

### DIFF
--- a/SpatialConnect.xcodeproj/project.pbxproj
+++ b/SpatialConnect.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		44D89B002036780B000B0A5E /* SCActions.h in Headers */ = {isa = PBXBuildFile; fileRef = 44D89AFF2036780B000B0A5E /* SCActions.h */; };
+		44D89B0620367823000B0A5E /* SCAction.m in Sources */ = {isa = PBXBuildFile; fileRef = 44D89B0520367823000B0A5E /* SCAction.m */; };
 		44DF99571DFFA05800AAAAA0 /* SCWFSTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 44DF99561DFFA05800AAAAA0 /* SCWFSTest.m */; };
 		5406C9CE1F94F1FA00B076F3 /* SCExchangeAuthMethod.h in Headers */ = {isa = PBXBuildFile; fileRef = 5406C9CC1F94F1FA00B076F3 /* SCExchangeAuthMethod.h */; };
 		5406C9CF1F94F1FA00B076F3 /* SCExchangeAuthMethod.m in Sources */ = {isa = PBXBuildFile; fileRef = 5406C9CD1F94F1FA00B076F3 /* SCExchangeAuthMethod.m */; };
@@ -466,6 +468,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		44D89AFF2036780B000B0A5E /* SCActions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SCActions.h; sourceTree = "<group>"; };
+		44D89B0520367823000B0A5E /* SCAction.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SCAction.m; sourceTree = "<group>"; };
 		44DF99561DFFA05800AAAAA0 /* SCWFSTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SCWFSTest.m; sourceTree = "<group>"; };
 		5406C9CC1F94F1FA00B076F3 /* SCExchangeAuthMethod.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SCExchangeAuthMethod.h; sourceTree = "<group>"; };
 		5406C9CD1F94F1FA00B076F3 /* SCExchangeAuthMethod.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SCExchangeAuthMethod.m; sourceTree = "<group>"; };
@@ -1558,6 +1562,8 @@
 			children = (
 				562EC6561E901B8B003D9F2C /* Actions.h */,
 				562EC6571E901B8B003D9F2C /* Actions.m */,
+				44D89AFF2036780B000B0A5E /* SCActions.h */,
+				44D89B0520367823000B0A5E /* SCAction.m */,
 			);
 			name = Actions;
 			sourceTree = "<group>";
@@ -1874,6 +1880,7 @@
 				566B1AF31D91B72F00A545A4 /* SCRemoteConfig.h in Headers */,
 				5649B5881BE280D6009947EF /* SCComparisonPredicate.h in Headers */,
 				56FB3EB91CF6A2BD00C3DA4B /* FMDatabaseAdditions.h in Headers */,
+				44D89B002036780B000B0A5E /* SCActions.h in Headers */,
 				56A23B051D79EFEA00AB258B /* SCBoundingBox+GeoJSON.h in Headers */,
 				56DBFA0C1D2F269C00FFE4FF /* KeychainItemWrapper.h in Headers */,
 				565E9ECE1DB7C49F00AEAB60 /* SCCache.h in Headers */,
@@ -2255,6 +2262,7 @@
 				5649B5B31BE280D6009947EF /* SCGeoFilterContains.m in Sources */,
 				5649B5AC1BE280D6009947EF /* SCFilterNotIn.m in Sources */,
 				5649B6081BE280D6009947EF /* SCSensorService.m in Sources */,
+				44D89B0620367823000B0A5E /* SCAction.m in Sources */,
 				561685FD1C74E69D00FC7FA6 /* SCGpkgGeometryColumnsTable.m in Sources */,
 				561686131C75194D00FC7FA6 /* SCGpkgDataColumnConstraint.m in Sources */,
 				566F6E431CE3B5680043FF0C /* SCFormConfig.m in Sources */,

--- a/SpatialConnect/SCAction.m
+++ b/SpatialConnect/SCAction.m
@@ -1,0 +1,10 @@
+//
+//  SCAction.m
+//  SpatialConnect
+//
+//  Created by Landon Robinson on 2/15/18.
+//  Copyright © 2018 Boundless Spatial. All rights reserved.
+//
+
+NSString *const DELETE_SC_DATASTORE = @"DELETE_SC_DATASTORE";
+NSString *const DELETE_ALL_SC_DATASTORES = @"DELETE_ALL_SC_DATASTORES";

--- a/SpatialConnect/SCActions.h
+++ b/SpatialConnect/SCActions.h
@@ -15,9 +15,10 @@
  */
 
 /*!
- * A list of actions that don't belong in the schema project because they are only relevant
- * to the mobile SDK domain.  If more than one service will send the action, then move it to the
- * schema repo so it can be accessed from com.boundlessgeo.schema.Actions.
+ * A list of actions that don't belong in the schema project because they are
+ * only relevant to the mobile SDK domain.  If more than one service will send
+ * the action, then move it to the schema repo so it can be accessed from
+ * com.boundlessgeo.schema.Actions.
  */
 
 extern NSString *const DELETE_SC_DATASTORE;

--- a/SpatialConnect/SCActions.h
+++ b/SpatialConnect/SCActions.h
@@ -1,0 +1,24 @@
+/*!
+ * Copyright 2018 Boundless http://boundlessgeo.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+/*!
+ * A list of actions that don't belong in the schema project because they are only relevant
+ * to the mobile SDK domain.  If more than one service will send the action, then move it to the
+ * schema repo so it can be accessed from com.boundlessgeo.schema.Actions.
+ */
+
+extern NSString *const DELETE_SC_DATASTORE;
+extern NSString *const DELETE_ALL_SC_DATASTORES;

--- a/SpatialConnect/SCDataStore.m
+++ b/SpatialConnect/SCDataStore.m
@@ -97,6 +97,7 @@
         [[SCHttpUtils getRequestURLAsData:u] subscribeNext:^(RACTuple *t) {
           data = t.first;
           self.downloadProgress = t.second;
+          DDLogWarn(@"Download progress at %@ ", self.downloadProgress);
           [subscriber sendNext:t];
         }
             error:^(NSError *error) {

--- a/SpatialConnect/SCJavascriptBridgeAPI.m
+++ b/SpatialConnect/SCJavascriptBridgeAPI.m
@@ -440,11 +440,12 @@
 }
 
 - (void)addStore:(NSDictionary *)storeConfig
-      responseSubscriber:(id<RACSubscriber>)subscriber {
+    responseSubscriber:(id<RACSubscriber>)subscriber {
   SCConfigService *cs = [[SpatialConnect sharedInstance] configService];
   SCDataService *ds = [[SpatialConnect sharedInstance] dataService];
   SCConfig *cachedConfig = cs.cachedConfig;
-  SCStoreConfig *config = [[SCStoreConfig alloc] initWithDictionary:storeConfig];
+  SCStoreConfig *config =
+      [[SCStoreConfig alloc] initWithDictionary:storeConfig];
   [cachedConfig addStore:config];
   [ds registerAndStartStoreByConfig:config];
   [subscriber sendCompleted];
@@ -453,8 +454,8 @@
 - (void)deleteAllDataStores:(id<RACSubscriber>)subscriber {
   SCDataService *ds = [[SpatialConnect sharedInstance] dataService];
   NSArray *storeList = [ds storeList];
-  [storeList enumerateObjectsUsingBlock:^(SCDataStore *store,
-                                    NSUInteger idx, BOOL *stop) {
+  [storeList enumerateObjectsUsingBlock:^(SCDataStore *store, NSUInteger idx,
+                                          BOOL *stop) {
     [ds unregisterStore:store];
   }];
   [subscriber sendCompleted];
@@ -463,11 +464,11 @@
 - (void)deleteDataStore:(NSDictionary *)value
      responseSubscriber:(id<RACSubscriber>)subscriber {
   SCDataService *ds = [[SpatialConnect sharedInstance] dataService];
-  SCDataStore *store =
-    [[[SpatialConnect sharedInstance] dataService] storeByIdentifier:value[@"storeId"]];
+  SCDataStore *store = [[[SpatialConnect sharedInstance] dataService]
+      storeByIdentifier:value[@"storeId"]];
   [ds unregisterStore:store];
   DDLogWarn(@"---->>>>> Deleted data store");
   [subscriber sendCompleted];
 }
-  
+
 @end

--- a/SpatialConnect/SCJavascriptBridgeAPI.m
+++ b/SpatialConnect/SCJavascriptBridgeAPI.m
@@ -94,6 +94,8 @@
       [self getBackendUri:subscriber];
     else if ([actionType isEqualToString:BACKENDSERVICE_MQTT_CONNECTED])
       [self mqttConnected:subscriber];
+    else if ([actionType isEqualToString:CONFIG_ADD_STORE])
+      [self addStore:action[@"payload"] responseSubscriber:subscriber];
 
     return nil;
   }];
@@ -432,4 +434,14 @@
       }];
 }
 
+- (void)addStore:(NSDictionary *)storeConfig
+      responseSubscriber:(id<RACSubscriber>)subscriber {
+  SCConfigService *cs = [[SpatialConnect sharedInstance] configService];
+  SCDataService *ds = [[SpatialConnect sharedInstance] dataService];
+  SCConfig *cachedConfig = cs.cachedConfig;
+  SCStoreConfig *config = [[SCStoreConfig alloc] initWithDictionary:storeConfig];
+  [cachedConfig addStore:config];
+  [ds registerAndStartStoreByConfig:config];
+}
+  
 @end


### PR DESCRIPTION
## Status
**IN DEVELOPMENT**

## Description
Add support to use sdks as data store only without location or forms stores

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] License

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

```sh
git fetch --all
git checkout <feature_branch> 
xctool -workspace SpatialConnect.xcworkspace -scheme SpatialConnect -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6 Plus' ONLY_ACTIVE_ARCH=NO test
```

@boundlessgeo/spatial-connect
